### PR TITLE
회원가입 시 학교 이메일 도메인 검증 기능 추가, Swagger에 공통 예외처리 문서 추가

### DIFF
--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/member/controller/MemberController.java
@@ -38,7 +38,7 @@ public class MemberController {
   @Operation(summary = "학생 회원가입", description = "학생 계정으로 회원가입을 진행합니다.")
   @ApiResponses(value = {
           @ApiResponse(responseCode = "200", description = "회원가입 성공"),
-          @ApiResponse(responseCode = "400", description = "잘못된 요청 (입력값 누락, 이메일 미인증)"),
+          @ApiResponse(responseCode = "400", description = "잘못된 요청 (입력값 누락, 이메일 미인증, 학교 이메일 도메인 불일치)"),
           @ApiResponse(responseCode = "404", description = "존재하지 않는 대학 또는 전공"),
           @ApiResponse(responseCode = "409", description = "이메일 또는 학번이 이미 등록되어 있습니다.")
   })
@@ -51,7 +51,7 @@ public class MemberController {
   @Operation(summary = "교수 회원가입", description = "교수 계정으로 회원가입을 진행하며, 관리자의 승인을 기다려야 합니다.")
   @ApiResponses(value = {
           @ApiResponse(responseCode = "200", description = "회원가입 성공"),
-          @ApiResponse(responseCode = "400", description = "잘못된 요청 (입력값 누락, 이메일 미인증)"),
+          @ApiResponse(responseCode = "400", description = "잘못된 요청 (입력값 누락, 이메일 미인증, 학교 이메일 도메인 불일치)"),
           @ApiResponse(responseCode = "404", description = "존재하지 않는 대학 또는 전공"),
           @ApiResponse(responseCode = "409", description = "이메일 또는 학번이 이미 등록되어 있습니다.")
   })

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/member/exception/member/InvalidEmailDomainException.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/member/exception/member/InvalidEmailDomainException.java
@@ -1,0 +1,9 @@
+package com.WEB4_5_GPT_BE.unihub.domain.member.exception.member;
+
+import com.WEB4_5_GPT_BE.unihub.domain.member.exception.MemberException;
+
+public class InvalidEmailDomainException extends MemberException {
+    public InvalidEmailDomainException(String expectedDomain) {
+        super("400", "선택한 학교의 이메일 형식(@" + expectedDomain + ")과 일치하지 않습니다.");
+    }
+}

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/member/service/MemberServiceImpl.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/member/service/MemberServiceImpl.java
@@ -3,8 +3,14 @@ package com.WEB4_5_GPT_BE.unihub.domain.member.service;
 import com.WEB4_5_GPT_BE.unihub.domain.common.enums.ApprovalStatus;
 import com.WEB4_5_GPT_BE.unihub.domain.common.enums.Role;
 import com.WEB4_5_GPT_BE.unihub.domain.course.repository.CourseRepository;
-import com.WEB4_5_GPT_BE.unihub.domain.member.dto.request.*;
-import com.WEB4_5_GPT_BE.unihub.domain.member.dto.request.mypage.*;
+import com.WEB4_5_GPT_BE.unihub.domain.member.dto.request.EmailCodeVerificationRequest;
+import com.WEB4_5_GPT_BE.unihub.domain.member.dto.request.PasswordResetConfirmationRequest;
+import com.WEB4_5_GPT_BE.unihub.domain.member.dto.request.ProfessorSignUpRequest;
+import com.WEB4_5_GPT_BE.unihub.domain.member.dto.request.StudentSignUpRequest;
+import com.WEB4_5_GPT_BE.unihub.domain.member.dto.request.mypage.UpdateEmailRequest;
+import com.WEB4_5_GPT_BE.unihub.domain.member.dto.request.mypage.UpdateMajorRequest;
+import com.WEB4_5_GPT_BE.unihub.domain.member.dto.request.mypage.UpdatePasswordRequest;
+import com.WEB4_5_GPT_BE.unihub.domain.member.dto.request.mypage.VerifyPasswordRequest;
 import com.WEB4_5_GPT_BE.unihub.domain.member.dto.response.mypage.MyPageProfessorResponse;
 import com.WEB4_5_GPT_BE.unihub.domain.member.dto.response.mypage.MyPageStudentResponse;
 import com.WEB4_5_GPT_BE.unihub.domain.member.dto.response.mypage.ProfessorCourseResponse;
@@ -29,7 +35,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -134,8 +139,16 @@ public class MemberServiceImpl implements MemberService {
   private UniversityContext validateEmailAndLoadSchoolInfo(String email, Long universityId, Long majorId) {
     University university = universityService.findUniversityById(universityId);
     Major major = majorService.getMajor(universityId, majorId);
+    validateEmailDomainMatchesUniversity(email, university);
     validateEmailVerification(email);
     return new UniversityContext(university, major);
+  }
+
+  private void validateEmailDomainMatchesUniversity(String email, University university) {
+    String[] emailParts = email.split("@");
+    if (emailParts.length != 2 || !emailParts[1].equalsIgnoreCase(university.getEmailDomain())) {
+      throw new InvalidEmailDomainException(university.getEmailDomain());
+    }
   }
 
   private record UniversityContext(University university, Major major) {}

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/config/SwaggerConfig.java
@@ -25,7 +25,7 @@ public class SwaggerConfig {
                                 {
                                   "code": "에러코드 문자열 (예: 401, 401-1)",
                                   "message": "오류 메시지",
-                                  "data": null
+                                  "data": {}
                                 }
                                 ```
 

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/config/SwaggerConfig.java
@@ -45,9 +45,15 @@ public class SwaggerConfig {
                                 {
                                   "code": "401-1",
                                   "message": "AccessToken이 만료되었습니다.",
-                                  "data": null
+                                  "data": {}
                                 }
                                 ```
+                                
+                                ※ 오류 응답 시 `data` 필드는 `null` 또는 `{}`(빈 객체)로 응답됩니다. \s
+                                이는 응답 구조의 일관성을 위한 처리이며, 실제 오류 정보는 `code`와 `message` 필드를 통해 전달됩니다. \s
+                                성공 응답에서만 `data`에 실제 데이터가 포함되며, Swagger에 표시되는 예시는 성공 응답 기준으로 자동 생성된 것입니다. \s
+                                정확한 오류 응답 구조는 위 JSON 예시를 참고해주세요.
+                                
                                 """));
     }
 }

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/config/SwaggerConfig.java
@@ -1,0 +1,53 @@
+package com.WEB4_5_GPT_BE.unihub.global.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("UniHub API 명세서")
+                        .version("v1.0.0")
+                        .description("""
+                                ### 📌 공통 오류 응답 안내
+
+                                UniHub의 모든 API는 다음과 같은 공통 오류 응답 포맷을 따릅니다.  
+                                (HTTP 상태코드와 응답 바디 내 `"code"` 필드는 다를 수 있습니다.)
+
+                                #### 🔁 공통 응답 JSON 형식
+                                ```json
+                                {
+                                  "code": "에러코드 문자열 (예: 401, 401-1)",
+                                  "message": "오류 메시지",
+                                  "data": null
+                                }
+                                ```
+
+                                #### ❗ 오류 코드 목록
+
+                                | HTTP Status | code (문자열) | 의미 |
+                                |-------------|----------------|------|
+                                | 400         | "400"           | 잘못된 요청 (본문 오류 등) |
+                                | 401         | "401"           | 인증 실패 – 로그인 필요 |
+                                | 401         | "401-1"         | AccessToken 만료됨 |
+                                | 403         | "403"           | 권한 없음 |
+                                | 404         | "404"           | 존재하지 않는 사용자 |
+                                | 500         | "500"           | 서버 오류 |
+
+                                #### 📦 예시
+                                ```json
+                                {
+                                  "code": "401-1",
+                                  "message": "AccessToken이 만료되었습니다.",
+                                  "data": null
+                                }
+                                ```
+                                """));
+    }
+}

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/init/InitDataHelper.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/init/InitDataHelper.java
@@ -45,8 +45,8 @@ public class InitDataHelper {
     private final EnrollmentRepository enrollmentRepository;
     private final EnrollmentPeriodRepository enrollmentPeriodRepository;
 
-    public University createUniversity(String name) {
-        return universityRepository.save(University.builder().name(name).emailDomain("unihub.ac.kr").build());
+    public University createUniversity(String name, String emailDomain) {
+        return universityRepository.save(University.builder().name(name).emailDomain(emailDomain).build());
     }
 
     public Major createMajor(String name, University university) {

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/init/InitDevData.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/init/InitDevData.java
@@ -32,7 +32,7 @@ public class InitDevData {
             return;
         }
 
-        University university = helper.createUniversity("A대학교");
+        University university = helper.createUniversity("A대학교", "auni.ac.kr");
         Major major = helper.createMajor("소프트웨어전공", university);
         Major major2 = helper.createMajor("컴퓨터공학전공", university);
 

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/init/InitProdOrStgData.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/init/InitProdOrStgData.java
@@ -29,7 +29,7 @@ public class InitProdOrStgData {
             return;
         }
 
-        University university = helper.createUniversity("A대학교");
+        University university = helper.createUniversity("A대학교", "auni.ac.kr");
         Major major = helper.createMajor("소프트웨어전공", university);
         Major major2 = helper.createMajor("컴퓨터공학전공", university);
 

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/init/InitTestData.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/init/InitTestData.java
@@ -34,7 +34,7 @@ public class InitTestData {
         studentProfileRepository.deleteAll();
         helper.clearAllMemberData();
 
-        University university = helper.createUniversity("A대학교");
+        University university = helper.createUniversity("A대학교", "auni.ac.kr");
         Major major = helper.createMajor("소프트웨어전공", university);
         Major major2 = helper.createMajor("컴퓨터공학전공", university);
 

--- a/backend/src/test/java/com/WEB4_5_GPT_BE/unihub/domain/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/WEB4_5_GPT_BE/unihub/domain/member/controller/MemberControllerTest.java
@@ -174,6 +174,22 @@ public class MemberControllerTest {
     }
 
     @Test
+    @DisplayName("학생 회원가입 실패 - 이메일 도메인이 학교와 일치하지 않음")
+    void signUpStudent_invalidEmailDomain_thenFail() throws Exception {
+        String email = "wrong@notmatched.com";
+        when(emailService.isAlreadyVerified(email)).thenReturn(true);
+
+        StudentSignUpRequest request = new StudentSignUpRequest(
+                email, "password", "학생", "20251234", 1L, 1L, 1, 1, Role.STUDENT);
+
+        mockMvc.perform(post("/api/members/signup/student")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("선택한 학교의 이메일 형식(@auni.ac.kr)과 일치하지 않습니다."));
+    }
+
+    @Test
     @DisplayName("내 정보 조회 - 학생")
     void getMyInfo_student_success() throws Exception {
         MemberLoginRequest request = new MemberLoginRequest("teststudent@auni.ac.kr", "password");

--- a/backend/src/test/java/com/WEB4_5_GPT_BE/unihub/domain/member/service/MemberServiceImplTest.java
+++ b/backend/src/test/java/com/WEB4_5_GPT_BE/unihub/domain/member/service/MemberServiceImplTest.java
@@ -18,6 +18,7 @@ import com.WEB4_5_GPT_BE.unihub.domain.university.entity.University;
 import com.WEB4_5_GPT_BE.unihub.domain.university.service.MajorService;
 import com.WEB4_5_GPT_BE.unihub.domain.university.service.UniversityService;
 import com.WEB4_5_GPT_BE.unihub.global.exception.UnihubException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -61,24 +62,39 @@ class MemberServiceImplTest {
     @Mock
     private EmailService emailService;
 
+    private University mockUniversity;
+    private Major mockMajor;
+
+    @BeforeEach
+    void setUpCommonMocks() {
+        mockUniversity = University.builder()
+                .id(1L)
+                .name("A대학교")
+                .emailDomain("auni.ac.kr")
+                .build();
+
+        mockMajor = Major.builder()
+                .id(1L)
+                .name("소프트웨어전공")
+                .university(mockUniversity)
+                .build();
+    }
+
     @DisplayName("학생 회원가입에 성공한다")
     @Test
     void givenValidStudentSignUpRequest_whenSignUpStudent_thenMemberSaved() {
         // given
         StudentSignUpRequest request =
                 new StudentSignUpRequest(
-                        "student@example.com", "password", "홍길동", "20240001", 1L, 1L, 1, 1, Role.STUDENT);
-
-        University university = University.builder().id(1L).name("테스트대학").build();
-        Major major = Major.builder().id(1L).name("컴퓨터공학과").university(university).build();
+                        "student@auni.ac.kr", "password", "홍길동", "20240001", 1L, 1L, 1, 1, Role.STUDENT);
 
         when(emailService.isAlreadyVerified(request.email())).thenReturn(true);
         when(memberRepository.existsByEmail(request.email())).thenReturn(false);
         when(studentProfileRepository.existsByStudentCodeAndUniversityId(
                 request.studentCode(), request.universityId()))
                 .thenReturn(false);
-        when(universityService.findUniversityById(request.universityId())).thenReturn(university);
-        when(majorService.getMajor(request.universityId(), request.majorId())).thenReturn(major);
+        when(universityService.findUniversityById(request.universityId())).thenReturn(mockUniversity);
+        when(majorService.getMajor(request.universityId(), request.majorId())).thenReturn(mockMajor);
         when(passwordEncoder.encode(request.password())).thenReturn("encodedPassword");
 
         // when
@@ -93,8 +109,10 @@ class MemberServiceImplTest {
     void givenUnverifiedEmail_whenSignUpStudent_thenThrowUnihubException() {
         // given
         StudentSignUpRequest request = new StudentSignUpRequest(
-                "student@example.com", "password", "홍길동", "20240001", 1L, 1L, 1, 1, Role.STUDENT);
+                "student@auni.ac.kr", "password", "홍길동", "20240001", 1L, 1L, 1, 1, Role.STUDENT);
 
+        when(universityService.findUniversityById(1L)).thenReturn(mockUniversity);
+        when(majorService.getMajor(1L, 1L)).thenReturn(mockMajor);
         when(emailService.isAlreadyVerified(request.email())).thenReturn(false); // 인증 안 됨
 
         // when / then
@@ -108,8 +126,10 @@ class MemberServiceImplTest {
     void givenDuplicatedEmail_whenSignUpStudent_thenThrowUnihubException() {
         // given
         StudentSignUpRequest request = new StudentSignUpRequest(
-                "student@example.com", "password", "홍길동", "20240001", 1L, 1L, 1, 1, Role.STUDENT);
+                "student@auni.ac.kr", "password", "홍길동", "20240001", 1L, 1L, 1, 1, Role.STUDENT);
 
+        when(universityService.findUniversityById(1L)).thenReturn(mockUniversity);
+        when(majorService.getMajor(1L, 1L)).thenReturn(mockMajor);
         when(emailService.isAlreadyVerified(request.email())).thenReturn(true); // 인증 됨
         when(memberRepository.existsByEmail(request.email())).thenReturn(true);
 
@@ -125,7 +145,7 @@ class MemberServiceImplTest {
         // given
         long invalidUniversityId = 9999L;
         StudentSignUpRequest request = new StudentSignUpRequest(
-                "student@example.com", "password", "홍길동", "20240001", invalidUniversityId, 1L, 1, 1, Role.STUDENT);
+                "student@auni.ac.kr", "password", "홍길동", "20240001", invalidUniversityId, 1L, 1, 1, Role.STUDENT);
         
         when(universityService.findUniversityById(eq(invalidUniversityId)))
                 .thenThrow(new UnihubException("404", "해당 대학이 존재하지 않습니다."));
@@ -142,7 +162,7 @@ class MemberServiceImplTest {
         // given
         StudentSignUpRequest request =
                 new StudentSignUpRequest(
-                        "student@example.com", "password", "홍길동", "20240001", 1L, 9999L, 1, 1, Role.STUDENT);
+                        "student@auni.ac.kr", "password", "홍길동", "20240001", 1L, 9999L, 1, 1, Role.STUDENT);
 
         University university = University.builder().id(1L).name("테스트대학").build();
 
@@ -162,18 +182,15 @@ class MemberServiceImplTest {
         // given
         ProfessorSignUpRequest request =
                 new ProfessorSignUpRequest(
-                        "professor@example.com", "password", "김교수", "EMP20240001", 1L, 1L, Role.PROFESSOR);
-
-        University university = University.builder().id(1L).name("테스트대학").build();
-        Major major = Major.builder().id(1L).name("소프트웨어학과").university(university).build();
+                        "professor@auni.ac.kr", "password", "김교수", "EMP20240001", 1L, 1L, Role.PROFESSOR);
 
         when(emailService.isAlreadyVerified(request.email())).thenReturn(true);
         when(memberRepository.existsByEmail(request.email())).thenReturn(false);
         when(professorProfileRepository.existsByEmployeeIdAndUniversityId(
                 request.employeeId(), request.universityId()))
                 .thenReturn(false);
-        when(universityService.findUniversityById(request.universityId())).thenReturn(university);
-        when(majorService.getMajor(request.universityId(), request.majorId())).thenReturn(major);
+        when(universityService.findUniversityById(request.universityId())).thenReturn(mockUniversity);
+        when(majorService.getMajor(request.universityId(), request.majorId())).thenReturn(mockMajor);
         when(passwordEncoder.encode(request.password())).thenReturn("encodedPassword");
 
         // when
@@ -189,17 +206,14 @@ class MemberServiceImplTest {
         // given
         ProfessorSignUpRequest request =
                 new ProfessorSignUpRequest(
-                        "professor@example.com", "password", "김교수", "EMP20240001", 1L, 1L, Role.PROFESSOR);
-
-        University university = University.builder().id(1L).name("테스트대학").build();
-        Major major = Major.builder().id(1L).name("소프트웨어학과").university(university).build();
+                        "professor@auni.ac.kr", "password", "김교수", "EMP20240001", 1L, 1L, Role.PROFESSOR);
 
         when(emailService.isAlreadyVerified(request.email())).thenReturn(true);
         when(memberRepository.existsByEmail(request.email())).thenReturn(false);
         when(professorProfileRepository.existsByEmployeeIdAndUniversityId(
                 request.employeeId(), request.universityId())).thenReturn(false);
-        when(universityService.findUniversityById(request.universityId())).thenReturn(university);
-        when(majorService.getMajor(request.universityId(), request.majorId())).thenReturn(major);
+        when(universityService.findUniversityById(request.universityId())).thenReturn(mockUniversity);
+        when(majorService.getMajor(request.universityId(), request.majorId())).thenReturn(mockMajor);
         when(passwordEncoder.encode(request.password())).thenReturn("encodedPassword");
 
         // 캡처용 ArgumentCaptor 추가
@@ -221,8 +235,10 @@ class MemberServiceImplTest {
     void givenUnverifiedEmail_whenSignUpProfessor_thenThrowUnihubException() {
         // given
         ProfessorSignUpRequest request = new ProfessorSignUpRequest(
-                "professor@example.com", "password", "김교수", "EMP20240001", 1L, 1L, Role.PROFESSOR);
+                "professor@auni.ac.kr", "password", "김교수", "EMP20240001", 1L, 1L, Role.PROFESSOR);
 
+        when(universityService.findUniversityById(1L)).thenReturn(mockUniversity);
+        when(majorService.getMajor(1L, 1L)).thenReturn(mockMajor);
         when(emailService.isAlreadyVerified(request.email())).thenReturn(false); // 인증 안 됨
 
         // when / then
@@ -236,8 +252,10 @@ class MemberServiceImplTest {
     void givenDuplicatedEmail_whenSignUpProfessor_thenThrowUnihubException() {
         // given
         ProfessorSignUpRequest request = new ProfessorSignUpRequest(
-                "professor@example.com", "password", "김교수", "EMP20240001", 1L, 1L, Role.PROFESSOR);
+                "professor@auni.ac.kr", "password", "김교수", "EMP20240001", 1L, 1L, Role.PROFESSOR);
 
+        when(universityService.findUniversityById(1L)).thenReturn(mockUniversity);
+        when(majorService.getMajor(1L, 1L)).thenReturn(mockMajor);
         when(emailService.isAlreadyVerified(request.email())).thenReturn(true);
         when(memberRepository.existsByEmail(request.email())).thenReturn(true);
 
@@ -251,7 +269,7 @@ class MemberServiceImplTest {
     @DisplayName("이메일 인증 요청 시 sendVerificationCode를 호출한다")
     void givenEmail_whenSendVerificationCode_thenInvokeEmailService() {
         // given
-        String email = "test@example.com";
+        String email = "test@auni.ac.kr";
 
         // when
         memberService.sendVerificationCode(email);
@@ -264,7 +282,7 @@ class MemberServiceImplTest {
     @Test
     void givenValidVerificationCode_whenVerifyEmailCode_thenMarkVerifiedAndDeleteCode() {
         // given
-        String email = "test@example.com";
+        String email = "test@auni.ac.kr";
         String code = "123456";
 
         EmailCodeVerificationRequest request = new EmailCodeVerificationRequest(email, code);
@@ -283,7 +301,7 @@ class MemberServiceImplTest {
     @Test
     void givenInvalidVerificationCode_whenVerifyEmailCode_thenThrowUnihubException() {
         // given
-        String email = "test@example.com";
+        String email = "test@auni.ac.kr";
         String wrongCode = "654321";
 
         EmailCodeVerificationRequest request = new EmailCodeVerificationRequest(email, wrongCode);
@@ -301,7 +319,7 @@ class MemberServiceImplTest {
     @Test
     void givenValidRequest_whenResetPassword_thenPasswordUpdated() {
         // given
-        String email = "test@example.com";
+        String email = "test@auni.ac.kr";
         String newPassword = "newPassword123";
 
         Member member =
@@ -330,7 +348,7 @@ class MemberServiceImplTest {
     @Test
     void givenNonExistentEmail_whenResetPassword_thenThrowUnihubException() {
         // given
-        String email = "nonexistent@example.com";
+        String email = "nonexistent@auni.ac.kr";
         String newPassword = "newPassword123";
 
         when(memberRepository.findByEmail(email)).thenReturn(java.util.Optional.empty());
@@ -348,7 +366,7 @@ class MemberServiceImplTest {
     @Test
     void givenSamePassword_whenResetPassword_thenThrowUnihubException() {
         // given
-        String email = "test@example.com";
+        String email = "test@auni.ac.kr";
         String samePassword = "samePassword123";
 
         Member member =


### PR DESCRIPTION
## ✨ 변경 사항 설명
- 학생/교직원 회원가입 시 입력된 이메일의 도메인이 선택한 학교의 이메일 도메인과 일치하는지 검증하는 로직을 추가했습니다.
- 도메인이 불일치할 경우 `InvalidEmailDomainException`을 통해 400 에러를 반환합니다.
- `InvalidEmailDomainException` 예외 클래스 추가
- `MemberServiceImpl` 내 `validateEmailDomainMatchesUniversity()` 메서드 추가
- 테스트 데이터 (InitTestData/Dev/Prod) emailDomain 필드 추가
- 단위 테스트 (`MemberServiceImplTest`) 및 통합 테스트 (`MemberControllerTest`)에 이메일 도메인 불일치 케이스 추가
- Swagger에 공통 예외처리 문서 추가


## ✅ 체크리스트

<!-- 📝 완료된 항목은 [x]로 표시해주세요. -->

- [ ] 🏗️ 코드가 **코딩 스타일 가이드**를 준수합니다.
- [x] 🧪 변경 사항에 대한 **테스트가 추가**되었습니다.
- [x] ✅ 모든 **테스트가 정상적으로 통과**합니다.
- [ ] 📚 필요한 **문서가 업데이트**되었습니다.

## 🎨 스크린샷 (UI 변경이 있는 경우)

![image](https://github.com/user-attachments/assets/c8733050-4550-411e-9fb0-56cb5e5dc7d0)
![image](https://github.com/user-attachments/assets/3bea1051-8531-409c-a4e3-d99e46f67c50)



## 🛠️ 테스트 방법 (필요시)

- Postman 또는 Swagger에서 회원가입 API 호출 시, 이메일 도메인을 다른 학교 도메인으로 바꾸면 400 에러 발생 확인
- 테스트 코드 실행 시 실패/성공 시나리오 모두 통과
