### PR TITLE
docs:  수강신청 api swagger 문서화

### DIFF
--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/controller/EnrollmentController.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/controller/EnrollmentController.java
@@ -5,11 +5,18 @@ import com.WEB4_5_GPT_BE.unihub.domain.enrollment.dto.request.EnrollmentRequest;
 import com.WEB4_5_GPT_BE.unihub.domain.enrollment.dto.response.MyEnrollmentResponse;
 import com.WEB4_5_GPT_BE.unihub.domain.enrollment.exception.*;
 import com.WEB4_5_GPT_BE.unihub.domain.enrollment.service.EnrollmentService;
+import com.WEB4_5_GPT_BE.unihub.domain.enrollment.springDoc.apiResponse.EnrollmentApiResponse;
+import com.WEB4_5_GPT_BE.unihub.domain.enrollment.springDoc.apiResponse.EnrollmentCancelApiResponse;
+import com.WEB4_5_GPT_BE.unihub.domain.enrollment.springDoc.apiResponse.GetMyEnrollmentListApiResponse;
 import com.WEB4_5_GPT_BE.unihub.domain.member.entity.Member;
 import com.WEB4_5_GPT_BE.unihub.global.Rq;
 import com.WEB4_5_GPT_BE.unihub.global.response.Empty;
 import com.WEB4_5_GPT_BE.unihub.global.response.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -18,9 +25,11 @@ import java.util.List;
  * 수강 신청, 취소, 내 수강목록 조회 등의
  * 수강 신청 관련 API 요청을 처리하는 컨트롤러입니다.
  */
+@Tag(name = "Enrollment", description = "수강신청 관련 API (수강신청, 취소, 내 수강목록 조회)")
+@SecurityRequirement(name = "accessToken을 사용한 bearerAuth 로그인 인증") // 해당 controller의 모든 Api에 accessToken 로그인이 필요하여 전역 적용함
 @RestController
-@RequestMapping("/api/enrollments")
 @RequiredArgsConstructor
+@RequestMapping(value = "/api/enrollments", produces = MediaType.APPLICATION_JSON_VALUE + ";charset=UTF-8")
 public class EnrollmentController {
 
     private final EnrollmentService enrollmentService;
@@ -32,7 +41,12 @@ public class EnrollmentController {
      *
      * @return 조회된 수강목록에 해당하는 {@link MyEnrollmentResponse} DTO 리스트
      */
-    @GetMapping("/me")
+    @Operation(
+            summary = "내 수강신청 목록 조회",
+            description = "로그인된 학생 본인의 수강신청 목록을 조회합니다. header에 Bearer accessToken이 없다면 접근할 수 없습니다."
+    )
+    @GetMyEnrollmentListApiResponse
+    @GetMapping(value = "/me")
     public RsData<List<MyEnrollmentResponse>> getMyEnrollmentList() {
 
         Member actor = rq.getActor(); // 인증된 사용자(Actor) 정보 획득
@@ -53,6 +67,11 @@ public class EnrollmentController {
      * @throws EnrollmentPeriodClosedException   수강신청 기간 외 요청인 경우
      * @throws EnrollmentNotFoundException       수강신청 내역이 없는 경우
      */
+    @Operation(
+            summary = "수강 취소",
+            description = "로그인된 학생이 특정 강좌 수강을 취소합니다. header에 Bearer accessToken이 없다면 접근할 수 없습니다."
+    )
+    @EnrollmentCancelApiResponse
     @DeleteMapping("/{courseId}")
     public RsData<Empty> enrollmentCancel(@PathVariable Long courseId) {
 
@@ -77,8 +96,12 @@ public class EnrollmentController {
      * @throws DuplicateEnrollmentException      동일 강좌 중복 신청 시
      * @throws CreditLimitExceededException      최대 학점 초과 시
      * @throws ScheduleConflictException         기존 신청한 강좌와 시간표가 겹치는 경우
-     * @throws EnrollmentNotFoundException       수강신청 내역이 없는 경우
      */
+    @Operation(
+            summary = "수강 신청",
+            description = "로그인된 학생이 특정 강좌에 수강 신청을 합니다. header에 Bearer accessToken이 없다면 접근할 수 없습니다."
+    )
+    @EnrollmentApiResponse
     @PostMapping
     public RsData<Empty> enrollment(@RequestBody EnrollmentRequest request) {
 

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/controller/EnrollmentController.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/controller/EnrollmentController.java
@@ -45,7 +45,7 @@ public class EnrollmentController {
             summary = "내 수강신청 목록 조회",
             description = "로그인된 학생 본인의 수강신청 목록을 조회합니다. header에 Bearer accessToken이 없다면 접근할 수 없습니다."
     )
-    @GetMyEnrollmentListApiResponse
+    @GetMyEnrollmentListApiResponse // api 요청에 대한 성공,예외 response 예시를 정의합니다.
     @GetMapping(value = "/me")
     public RsData<List<MyEnrollmentResponse>> getMyEnrollmentList() {
 
@@ -69,9 +69,10 @@ public class EnrollmentController {
      */
     @Operation(
             summary = "수강 취소",
-            description = "로그인된 학생이 특정 강좌 수강을 취소합니다. header에 Bearer accessToken이 없다면 접근할 수 없습니다."
+            description = "로그인된 학생이 특정 강좌 수강을 취소합니다. header에 Bearer accessToken이 없다면 접근할 수 없습니다.",
+            security = @SecurityRequirement(name = "accessToken을 사용한 bearerAuth 로그인 인증")
     )
-    @EnrollmentCancelApiResponse
+    @EnrollmentCancelApiResponse // api 요청에 대한 성공,예외 response 예시를 정의합니다.
     @DeleteMapping("/{courseId}")
     public RsData<Empty> enrollmentCancel(@PathVariable Long courseId) {
 
@@ -101,7 +102,7 @@ public class EnrollmentController {
             summary = "수강 신청",
             description = "로그인된 학생이 특정 강좌에 수강 신청을 합니다. header에 Bearer accessToken이 없다면 접근할 수 없습니다."
     )
-    @EnrollmentApiResponse
+    @EnrollmentApiResponse // api 요청에 대한 성공,예외 response 예시를 정의합니다.
     @PostMapping
     public RsData<Empty> enrollment(@RequestBody EnrollmentRequest request) {
 

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/springDoc/apiResponse/EnrollmentApiResponse.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/springDoc/apiResponse/EnrollmentApiResponse.java
@@ -17,138 +17,138 @@ import java.lang.annotation.RetentionPolicy;
 @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
-                description = "수강 신청 성공",
-                content = @Content(
-                        examples = @ExampleObject(
-                                value = """
-                                        {
-                                          "code": "200",
-                                          "message": "수강 신청이 완료되었습니다.",
-                                          "data": []
-                                        }
-                                        """
-                        )
-                )
+                description = "수강 신청 성공"
+//                ,content = @Content(
+//                        examples = @ExampleObject(
+//                                value = """
+//                                        {
+//                                          "code": "200",
+//                                          "message": "수강 신청이 완료되었습니다.",
+//                                          "data": []
+//                                        }
+//                                        """
+//                        )
+//                )
         ),
         @ApiResponse(
-                responseCode = "401-1",
-                description = "AccessToken이 만료된 경우",
-                content = @Content(
-                        examples = @ExampleObject(
-                                value = """
-                                        {
-                                          "code": "401-1",
-                                          "message": "AccessToken이 만료되었습니다.",
-                                          "data": {}
-                                        }
-                                        """
-                        )
+                responseCode = "401",
+                description = "AccessToken이 만료된 경우"
+                , content = @Content(
+                examples = @ExampleObject(
+                        value = """
+                                {
+                                  "code": "401-1",
+                                  "message": "AccessToken이 만료되었습니다.",
+                                  "data": {}
+                                }
+                                """
                 )
+        )
         ),
         @ApiResponse(
                 responseCode = "404",
-                description = "강좌 정보가 없는 경우",
-                content = @Content(
-                        examples = @ExampleObject(
-                                value = """
-                                        {
-                                          "code": "404",
-                                          "message": "강좌를 찾을 수 없습니다.",
-                                          "data": []
-                                        }
-                                        """
-                        )
-                )
+                description = "강좌 정보가 없는 경우"
+//                ,content = @Content(
+//                        examples = @ExampleObject(
+//                                value = """
+//                                        {
+//                                          "code": "404",
+//                                          "message": "강좌를 찾을 수 없습니다.",
+//                                          "data": []
+//                                        }
+//                                        """
+//                        )
+//                )
         ),
         @ApiResponse(
                 responseCode = "403",
-                description = "수강신청 기간 외 요청인 경우",
-                content = @Content(
-                        examples = @ExampleObject(
-                                value = """
-                                        {
-                                          "code": "403",
-                                          "message": "현재 수강신청 기간이 아닙니다.",
-                                          "data": []
-                                        }
-                                        """
-                        )
-                )
+                description = "수강신청 기간 외 요청인 경우"
+//                ,content = @Content(
+//                        examples = @ExampleObject(
+//                                value = """
+//                                        {
+//                                          "code": "403",
+//                                          "message": "현재 수강신청 기간이 아닙니다.",
+//                                          "data": []
+//                                        }
+//                                        """
+//                        )
+//                )
         ),
         @ApiResponse(
                 responseCode = "404",
-                description = "수강신청 기간 정보가 없는 경우",
-                content = @Content(
-                        examples = @ExampleObject(
-                                value = """
-                                        {
-                                          "code": "404",
-                                          "message": "수강신청 기간 정보가 없습니다.",
-                                          "data": []
-                                        }
-                                        """
-                        )
-                )
+                description = "수강신청 기간 정보가 없는 경우"
+//                ,content = @Content(
+//                        examples = @ExampleObject(
+//                                value = """
+//                                        {
+//                                          "code": "404",
+//                                          "message": "수강신청 기간 정보가 없습니다.",
+//                                          "data": []
+//                                        }
+//                                        """
+//                        )
+//                )
         ),
         @ApiResponse(
                 responseCode = "409",
-                description = "신청하려는 강의 정원 초과 시",
-                content = @Content(
-                        examples = @ExampleObject(
-                                value = """
-                                        {
-                                          "code": "409",
-                                          "message": "정원이 초과되어 수강 신청이 불가능합니다.",
-                                          "data": []
-                                        }
-                                        """
-                        )
-                )
+                description = "신청하려는 강의 정원 초과 시"
+//                ,content = @Content(
+//                        examples = @ExampleObject(
+//                                value = """
+//                                        {
+//                                          "code": "409",
+//                                          "message": "정원이 초과되어 수강 신청이 불가능합니다.",
+//                                          "data": []
+//                                        }
+//                                        """
+//                        )
+//                )
         ),
         @ApiResponse(
                 responseCode = "409",
-                description = "동일 강좌 중복 신청 시",
-                content = @Content(
-                        examples = @ExampleObject(
-                                value = """
-                                        {
-                                          "code": "409",
-                                          "message": "이미 신청한 강의입니다.",
-                                          "data": []
-                                        }
-                                        """
-                        )
-                )
+                description = "동일 강좌 중복 신청 시"
+//                ,content = @Content(
+//                        examples = @ExampleObject(
+//                                value = """
+//                                        {
+//                                          "code": "409",
+//                                          "message": "이미 신청한 강의입니다.",
+//                                          "data": []
+//                                        }
+//                                        """
+//                        )
+//                )
         ),
         @ApiResponse(
                 responseCode = "409",
-                description = "최대 학점(21)을 초과하여 수강 신청하는 경우",
-                content = @Content(
-                        examples = @ExampleObject(
-                                value = """
-                                        {
-                                          "code": "409",
-                                          "message": "학점 한도를 초과하여 수강신청할 수 없습니다.",
-                                          "data": []
-                                        }
-                                        """
-                        )
-                )
+                description = "최대 학점(21)을 초과하여 수강 신청하는 경우"
+//                ,content = @Content(
+//                        examples = @ExampleObject(
+//                                value = """
+//                                        {
+//                                          "code": "409",
+//                                          "message": "학점 한도를 초과하여 수강신청할 수 없습니다.",
+//                                          "data": []
+//                                        }
+//                                        """
+//                        )
+//                )
         ),
         @ApiResponse(
                 responseCode = "409",
-                description = " 기존 신청한 강좌와 시간표가 겹치는 경우",
-                content = @Content(
-                        examples = @ExampleObject(
-                                value = """
-                                        {
-                                          "code": "409",
-                                          "message": "기존 신청한 강좌와 시간표가 겹칩니다.",
-                                          "data": []
-                                        }
-                                        """
-                        )
-                )
+                description = " 기존 신청한 강좌와 시간표가 겹치는 경우"
+//                ,content = @Content(
+//                        examples = @ExampleObject(
+//                                value = """
+//                                        {
+//                                          "code": "409",
+//                                          "message": "기존 신청한 강좌와 시간표가 겹칩니다.",
+//                                          "data": []
+//                                        }
+//                                        """
+//                        )
+//                )
         )
 })
 public @interface EnrollmentApiResponse {

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/springDoc/apiResponse/EnrollmentApiResponse.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/springDoc/apiResponse/EnrollmentApiResponse.java
@@ -1,0 +1,155 @@
+package com.WEB4_5_GPT_BE.unihub.domain.enrollment.springDoc.apiResponse;
+
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * 수강 신청 API의 공통 응답 예시를 정의하는 메타 어노테이션입니다.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponses({
+        @ApiResponse(
+                responseCode = "200",
+                description = "수강 신청 성공",
+                content = @Content(
+                        examples = @ExampleObject(
+                                value = """
+                                        {
+                                          "code": "200",
+                                          "message": "수강 신청이 완료되었습니다.",
+                                          "data": []
+                                        }
+                                        """
+                        )
+                )
+        ),
+        @ApiResponse(
+                responseCode = "401-1",
+                description = "AccessToken이 만료된 경우",
+                content = @Content(
+                        examples = @ExampleObject(
+                                value = """
+                                        {
+                                          "code": "401-1",
+                                          "message": "AccessToken이 만료되었습니다.",
+                                          "data": {}
+                                        }
+                                        """
+                        )
+                )
+        ),
+        @ApiResponse(
+                responseCode = "404",
+                description = "강좌 정보가 없는 경우",
+                content = @Content(
+                        examples = @ExampleObject(
+                                value = """
+                                        {
+                                          "code": "404",
+                                          "message": "강좌를 찾을 수 없습니다.",
+                                          "data": []
+                                        }
+                                        """
+                        )
+                )
+        ),
+        @ApiResponse(
+                responseCode = "403",
+                description = "수강신청 기간 외 요청인 경우",
+                content = @Content(
+                        examples = @ExampleObject(
+                                value = """
+                                        {
+                                          "code": "403",
+                                          "message": "현재 수강신청 기간이 아닙니다.",
+                                          "data": []
+                                        }
+                                        """
+                        )
+                )
+        ),
+        @ApiResponse(
+                responseCode = "404",
+                description = "수강신청 기간 정보가 없는 경우",
+                content = @Content(
+                        examples = @ExampleObject(
+                                value = """
+                                        {
+                                          "code": "404",
+                                          "message": "수강신청 기간 정보가 없습니다.",
+                                          "data": []
+                                        }
+                                        """
+                        )
+                )
+        ),
+        @ApiResponse(
+                responseCode = "409",
+                description = "신청하려는 강의 정원 초과 시",
+                content = @Content(
+                        examples = @ExampleObject(
+                                value = """
+                                        {
+                                          "code": "409",
+                                          "message": "정원이 초과되어 수강 신청이 불가능합니다.",
+                                          "data": []
+                                        }
+                                        """
+                        )
+                )
+        ),
+        @ApiResponse(
+                responseCode = "409",
+                description = "동일 강좌 중복 신청 시",
+                content = @Content(
+                        examples = @ExampleObject(
+                                value = """
+                                        {
+                                          "code": "409",
+                                          "message": "이미 신청한 강의입니다.",
+                                          "data": []
+                                        }
+                                        """
+                        )
+                )
+        ),
+        @ApiResponse(
+                responseCode = "409",
+                description = "최대 학점(21)을 초과하여 수강 신청하는 경우",
+                content = @Content(
+                        examples = @ExampleObject(
+                                value = """
+                                        {
+                                          "code": "409",
+                                          "message": "학점 한도를 초과하여 수강신청할 수 없습니다.",
+                                          "data": []
+                                        }
+                                        """
+                        )
+                )
+        ),
+        @ApiResponse(
+                responseCode = "409",
+                description = " 기존 신청한 강좌와 시간표가 겹치는 경우",
+                content = @Content(
+                        examples = @ExampleObject(
+                                value = """
+                                        {
+                                          "code": "409",
+                                          "message": "기존 신청한 강좌와 시간표가 겹칩니다.",
+                                          "data": []
+                                        }
+                                        """
+                        )
+                )
+        )
+})
+public @interface EnrollmentApiResponse {
+}

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/springDoc/apiResponse/EnrollmentCancelApiResponse.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/springDoc/apiResponse/EnrollmentCancelApiResponse.java
@@ -1,0 +1,96 @@
+package com.WEB4_5_GPT_BE.unihub.domain.enrollment.springDoc.apiResponse;
+
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * 수강 취소 API의 공통 응답 예시를 정의하는 메타 어노테이션입니다.
+ * 모든 응답에 data 필드를 빈 리스트로 포함합니다.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponses({
+        @ApiResponse(
+                responseCode = "200",
+                description = "수강 취소가 완료되었습니다.",
+                content = @Content(
+                        examples = @ExampleObject(
+                                value = """
+                                        {
+                                          "code": "200",
+                                          "message": "수강 취소가 완료되었습니다.",
+                                          "data": []
+                                        }
+                                        """
+                        )
+                )
+        ),
+        @ApiResponse(
+                responseCode = "401-1",
+                description = "AccessToken이 만료된 경우",
+                content = @Content(
+                        examples = @ExampleObject(
+                                value = """
+                                        {
+                                          "code": "401-1",
+                                          "message": "AccessToken이 만료되었습니다.",
+                                          "data": {}
+                                        }
+                                        """
+                        )
+                )
+        ),
+        @ApiResponse(
+                responseCode = "404",
+                description = "수강신청 기간 정보가 없는 경우",
+                content = @Content(
+                        examples = @ExampleObject(
+                                value = """
+                                        {
+                                          "code": "404",
+                                          "message": "수강신청 기간 정보가 없습니다.",
+                                          "data": []
+                                        }
+                                        """
+                        )
+                )
+        ),
+        @ApiResponse(
+                responseCode = "403",
+                description = "수강신청 기간 외 요청인 경우",
+                content = @Content(
+                        examples = @ExampleObject(
+                                value = """
+                                        {
+                                          "code": "403",
+                                          "message": "현재 수강신청 기간이 아닙니다.",
+                                          "data": []
+                                        }
+                                        """
+                        )
+                )
+        ),
+        @ApiResponse(
+                responseCode = "404",
+                description = "수강신청 내역을 찾을 수 없음",
+                content = @Content(
+                        examples = @ExampleObject(
+                                value = """
+                                        {
+                                          "code": "404",
+                                          "message": "수강신청 내역이 존재하지 않습니다.",
+                                          "data": []
+                                        }
+                                        """
+                        )
+                )
+        )
+})
+public @interface EnrollmentCancelApiResponse {
+}

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/springDoc/apiResponse/EnrollmentCancelApiResponse.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/springDoc/apiResponse/EnrollmentCancelApiResponse.java
@@ -18,78 +18,78 @@ import java.lang.annotation.RetentionPolicy;
 @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
-                description = "수강 취소가 완료되었습니다.",
-                content = @Content(
-                        examples = @ExampleObject(
-                                value = """
-                                        {
-                                          "code": "200",
-                                          "message": "수강 취소가 완료되었습니다.",
-                                          "data": []
-                                        }
-                                        """
-                        )
-                )
+                description = "수강 취소 성공"
+//                ,content = @Content(
+//                        examples = @ExampleObject(
+//                                value = """
+//                                        {
+//                                          "code": "200",
+//                                          "message": "수강 취소가 완료되었습니다.",
+//                                          "data": []
+//                                        }
+//                                        """
+//                        )
+//                )
         ),
         @ApiResponse(
-                responseCode = "401-1",
-                description = "AccessToken이 만료된 경우",
-                content = @Content(
-                        examples = @ExampleObject(
-                                value = """
-                                        {
-                                          "code": "401-1",
-                                          "message": "AccessToken이 만료되었습니다.",
-                                          "data": {}
-                                        }
-                                        """
-                        )
+                responseCode = "401",
+                description = "AccessToken이 만료된 경우"
+                , content = @Content(
+                examples = @ExampleObject(
+                        value = """
+                                {
+                                  "code": "401-1",
+                                  "message": "AccessToken이 만료되었습니다.",
+                                  "data": {}
+                                }
+                                """
                 )
+        )
         ),
         @ApiResponse(
                 responseCode = "404",
-                description = "수강신청 기간 정보가 없는 경우",
-                content = @Content(
-                        examples = @ExampleObject(
-                                value = """
-                                        {
-                                          "code": "404",
-                                          "message": "수강신청 기간 정보가 없습니다.",
-                                          "data": []
-                                        }
-                                        """
-                        )
-                )
+                description = "수강신청 기간 정보가 없는 경우"
+//                ,content = @Content(
+//                        examples = @ExampleObject(
+//                                value = """
+//                                        {
+//                                          "code": "404",
+//                                          "message": "수강신청 기간 정보가 없습니다.",
+//                                          "data": []
+//                                        }
+//                                        """
+//                        )
+//                )
         ),
         @ApiResponse(
                 responseCode = "403",
-                description = "수강신청 기간 외 요청인 경우",
-                content = @Content(
-                        examples = @ExampleObject(
-                                value = """
-                                        {
-                                          "code": "403",
-                                          "message": "현재 수강신청 기간이 아닙니다.",
-                                          "data": []
-                                        }
-                                        """
-                        )
-                )
+                description = "수강신청 기간 외 요청인 경우"
+//                ,content = @Content(
+//                        examples = @ExampleObject(
+//                                value = """
+//                                        {
+//                                          "code": "403",
+//                                          "message": "현재 수강신청 기간이 아닙니다.",
+//                                          "data": []
+//                                        }
+//                                        """
+//                        )
+//                )
         ),
         @ApiResponse(
                 responseCode = "404",
-                description = "수강신청 내역을 찾을 수 없음",
-                content = @Content(
-                        examples = @ExampleObject(
-                                value = """
-                                        {
-                                          "code": "404",
-                                          "message": "수강신청 내역이 존재하지 않습니다.",
-                                          "data": []
-                                        }
-                                        """
-                        )
-                )
+                description = "수강신청 내역을 찾을 수 없음"
+//                ,content = @Content(
+//                        examples = @ExampleObject(
+//                                value = """
+//                                        {
+//                                          "code": "404",
+//                                          "message": "수강신청 내역이 존재하지 않습니다.",
+//                                          "data": []
+//                                        }
+//                                        """
+//                        )
+//                )
         )
 })
 public @interface EnrollmentCancelApiResponse {

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/springDoc/apiResponse/GetMyEnrollmentListApiResponse.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/springDoc/apiResponse/GetMyEnrollmentListApiResponse.java
@@ -1,0 +1,64 @@
+package com.WEB4_5_GPT_BE.unihub.domain.enrollment.springDoc.apiResponse;
+
+import com.WEB4_5_GPT_BE.unihub.domain.enrollment.dto.response.MyEnrollmentResponse;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * 내 수강신청 목록 조회 API의 공통 응답 예시를 정의하는 메타 어노테이션입니다.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponses({
+        @ApiResponse(
+                responseCode = "200",
+                description = "내 수강목록 조회 성공",
+                content = @Content(
+                        array = @ArraySchema(schema = @Schema(implementation = MyEnrollmentResponse.class)),
+                        examples = @ExampleObject(
+                                value = """
+                                        {
+                                          "code": "200",
+                                          "message": "내 수강목록 조회가 완료되었습니다.",
+                                          "data": [
+                                            {
+                                              "courseId": 1,
+                                              "courseName": "자료구조",
+                                              "credit": 3,
+                                              "location": "OO동 401호",
+                                              "schedules": [
+                                                { "dayOfWeek": "MON", "startTime": "09:00:00", "endTime": "10:30:00" }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                        """
+                        )
+                )
+        ),
+        @ApiResponse(
+                responseCode = "401-1",
+                description = "AccessToken이 만료된 경우",
+                content = @Content(
+                        examples = @ExampleObject(
+                                value = """
+                                        {
+                                          "code": "401-1",
+                                          "message": "AccessToken이 만료되었습니다.",
+                                          "data": {}
+                                        }
+                                        """
+                        )
+                )
+        )
+})
+public @interface GetMyEnrollmentListApiResponse {
+}

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/springDoc/apiResponse/GetMyEnrollmentListApiResponse.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/springDoc/apiResponse/GetMyEnrollmentListApiResponse.java
@@ -22,43 +22,43 @@ import java.lang.annotation.RetentionPolicy;
                 responseCode = "200",
                 description = "내 수강목록 조회 성공",
                 content = @Content(
-                        array = @ArraySchema(schema = @Schema(implementation = MyEnrollmentResponse.class)),
-                        examples = @ExampleObject(
-                                value = """
-                                        {
-                                          "code": "200",
-                                          "message": "내 수강목록 조회가 완료되었습니다.",
-                                          "data": [
-                                            {
-                                              "courseId": 1,
-                                              "courseName": "자료구조",
-                                              "credit": 3,
-                                              "location": "OO동 401호",
-                                              "schedules": [
-                                                { "dayOfWeek": "MON", "startTime": "09:00:00", "endTime": "10:30:00" }
-                                              ]
-                                            }
-                                          ]
-                                        }
-                                        """
-                        )
+                        array = @ArraySchema(schema = @Schema(implementation = MyEnrollmentResponse.class))
+//                        ,examples = @ExampleObject(
+//                                value = """
+//                                        {
+//                                          "code": "200",
+//                                          "message": "내 수강목록 조회가 완료되었습니다.",
+//                                          "data": [
+//                                            {
+//                                              "courseId": 1,
+//                                              "courseName": "자료구조",
+//                                              "credit": 3,
+//                                              "location": "OO동 401호",
+//                                              "schedules": [
+//                                                { "dayOfWeek": "MON", "startTime": "09:00:00", "endTime": "10:30:00" }
+//                                              ]
+//                                            }
+//                                          ]
+//                                        }
+//                                        """
+//                        )
                 )
         ),
         @ApiResponse(
-                responseCode = "401-1",
-                description = "AccessToken이 만료된 경우",
-                content = @Content(
-                        examples = @ExampleObject(
-                                value = """
-                                        {
-                                          "code": "401-1",
-                                          "message": "AccessToken이 만료되었습니다.",
-                                          "data": {}
-                                        }
-                                        """
-                        )
+                responseCode = "401",
+                description = "AccessToken이 만료된 경우"
+                , content = @Content(
+                examples = @ExampleObject(
+                        value = """
+                                {
+                                  "code": "401-1",
+                                  "message": "AccessToken이 만료되었습니다.",
+                                  "data": {}
+                                }
+                                """
                 )
         )
+        ),
 })
 public @interface GetMyEnrollmentListApiResponse {
 }

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/config/springDoc/SpringDocSecurityConfig.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/config/springDoc/SpringDocSecurityConfig.java
@@ -1,0 +1,21 @@
+package com.WEB4_5_GPT_BE.unihub.global.config.springDoc;
+
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Swagger UI에서 사용할 보안 스키마를 정의합니다.
+ * accessToken을 사용한 Bearer 인증 방식을 설정합니다.
+ */
+@Configuration
+@SecurityScheme(
+        name = "accessToken을 사용한 bearerAuth 로그인 인증",
+        type = SecuritySchemeType.HTTP,             // HTTP 방식의 인증
+        scheme = "bearer",                          // Bearer 인증 방식
+        bearerFormat = "JWT",                       // JWT 형식의 Bearer 토큰
+        in = SecuritySchemeIn.HEADER                // HTTP 헤더에서 인증 정보 포함
+)
+public class SpringDocSecurityConfig {
+}


### PR DESCRIPTION
## ✨ 변경 사항 설명

### 수강신청 관련 api에 대해 swagger 문서화 하였습니다.
---

<!-- 🔍 이 PR에서 변경된 내용을 간략하게 설명해주세요. -->
Swagger에 출력되는 response의 형태가
api명세서에 작성된 response처럼 더 직관적이도록 수정했습니다
![image](https://github.com/user-attachments/assets/109c3e7f-a73a-40f0-9626-35f8c4a07c21)
```
커스텀 어노테이션 형태로 구현하여 해당하는 api에 붙여주었습니다.

        @ApiResponse(
                responseCode = "404",
                description = "수강신청 내역을 찾을 수 없음",
                content = @Content(
                        examples = @ExampleObject(
                                value = """
                                        {
                                          "code": "404",
                                          "message": "수강신청 내역이 존재하지 않습니다.",
                                          "data": []
                                        }
                                        """
                        )
                )
        )
})
@Documented
public @interface EnrollmentCancelApiResponse {
}
```
![image](https://github.com/user-attachments/assets/79df09d6-7810-49f6-8f67-f4d4f934957b)




---
특정 api에 접근할 때 accessToken이 필요할 경우
해당 security를 적용해주면 swagger에서 accessToken을 입력할 수 있습니다
![image](https://github.com/user-attachments/assets/0ce0637b-d2e9-471e-8ffa-4e88251a201b)

![image](https://github.com/user-attachments/assets/7ffa1b91-1a7c-4843-90a1-741129d1b1c5)
![image](https://github.com/user-attachments/assets/5c90c372-6803-45bd-b4d2-2462099d1394)
---
만약 controller에 존재하는 모든 api에 accessToken이 필요하다면 controller단에만 적용해주어도 됩니다
![image](https://github.com/user-attachments/assets/df7b5349-93e4-4f30-a74a-4804e8c8bc85)

## ✅ 체크리스트

<!-- 📝 완료된 항목은 [x]로 표시해주세요. -->

- [ ] 🏗️ 코드가 **코딩 스타일 가이드**를 준수합니다.
- [ ] 🧪 변경 사항에 대한 **테스트가 추가**되었습니다.
- [ ] ✅ 모든 **테스트가 정상적으로 통과**합니다.
- [ ] 📚 필요한 **문서가 업데이트**되었습니다.

## 🎨 스크린샷 (UI 변경이 있는 경우)

<!-- 🖼️ 변경 전/후 스크린샷을 추가해주세요. -->

## 🛠️ 테스트 방법 (필요시)

<!-- 🧑‍💻 이 PR을 테스트하는 방법을 설명해주세요. -->
