### PR TITLE
[FIX] 강의 수정시 스케줄 검증 로직 수정

### DIFF
--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/course/repository/CourseScheduleRepository.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/course/repository/CourseScheduleRepository.java
@@ -5,7 +5,6 @@ import com.WEB4_5_GPT_BE.unihub.domain.course.entity.CourseSchedule;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
 
 import java.time.LocalTime;
 
@@ -13,33 +12,68 @@ public interface CourseScheduleRepository extends JpaRepository<CourseSchedule, 
 
     // TODO: 각 일에 대해 쿼리를 하나씩 보내기보다 강의에 해당하는 CourseSchedule을 목록으로 받아와 서비스에서 검증하도록 수정을 검토 할 것.
     @Query("""
-        SELECT COUNT(*) > 0
-        FROM CourseSchedule cs
-        WHERE (cs.professorProfileEmployeeId = :profId OR cs.professorProfileEmployeeId IS NULL)
-            AND cs.day = :dayOfWeek
-            AND ((:pStartTime <= cs.startTime AND cs.startTime < :pEndTime)
-            OR (:pStartTime < cs.endTime AND cs.endTime <= :pEndTime))
-    """)
+                SELECT COUNT(*) > 0
+                FROM CourseSchedule cs
+                WHERE cs.professorProfileEmployeeId = :profId
+                    AND cs.day = :dayOfWeek
+                    AND ((:pStartTime <= cs.startTime AND cs.startTime < :pEndTime)
+                    OR (:pStartTime < cs.endTime AND cs.endTime <= :pEndTime))
+            """)
     Boolean existsByProfEmpIdAndDayOfWeek(
             @Param("profId") String profId,
             @Param("dayOfWeek") DayOfWeek dayOfWeek,
             @Param("pStartTime") LocalTime pStartTime,
             @Param("pEndTime") LocalTime pEndTime);
 
+    @Query("""
+                SELECT COUNT(*) > 0
+                FROM CourseSchedule cs
+                WHERE cs.professorProfileEmployeeId = :profId
+                    AND cs.course.id != :courseId
+                    AND cs.day = :dayOfWeek
+                    AND ((:pStartTime <= cs.startTime AND cs.startTime < :pEndTime)
+                    OR (:pStartTime < cs.endTime AND cs.endTime <= :pEndTime))
+            """)
+    Boolean existsByProfEmpIdAndDayOfWeekExcludingCourse(
+            @Param("profId") String profId,
+            @Param("dayOfWeek") DayOfWeek dayOfWeek,
+            @Param("pStartTime") LocalTime pStartTime,
+            @Param("pEndTime") LocalTime pEndTime,
+            @Param("courseId") Long courseId
+    );
+
     // TODO: 위와 같음.
     @Query("""
-        SELECT COUNT(*) > 0
-        FROM CourseSchedule cs
-        WHERE cs.universityId = :univId
-            AND cs.location = :location
-            AND cs.day = :dayOfWeek
-            AND ((:pStartTime <= cs.startTime AND cs.startTime < :pEndTime)
-            OR (:pStartTime < cs.endTime AND cs.endTime <= :pEndTime))
-    """)
+                SELECT COUNT(*) > 0
+                FROM CourseSchedule cs
+                WHERE cs.universityId = :univId
+                    AND cs.location = :location
+                    AND cs.day = :dayOfWeek
+                    AND ((:pStartTime <= cs.startTime AND cs.startTime < :pEndTime)
+                    OR (:pStartTime < cs.endTime AND cs.endTime <= :pEndTime))
+            """)
     Boolean existsByUnivIdAndLocationAndDayOfWeek(
             @Param("univId") Long univId,
             @Param("location") String location,
             @Param("dayOfWeek") DayOfWeek dayOfWeek,
             @Param("pStartTime") LocalTime pStartTime,
             @Param("pEndTime") LocalTime pEndTime);
+
+    @Query("""
+                SELECT COUNT(*) > 0
+                FROM CourseSchedule cs
+                WHERE cs.universityId = :univId
+                    AND cs.location = :location
+                    AND cs.course.id != :courseId
+                    AND cs.day = :dayOfWeek
+                    AND ((:pStartTime <= cs.startTime AND cs.startTime < :pEndTime)
+                    OR (:pStartTime < cs.endTime AND cs.endTime <= :pEndTime))
+            """)
+    Boolean existsByUnivIdAndLocationAndDayOfWeekExcludingCourse(
+            @Param("univId") Long univId,
+            @Param("location") String location,
+            @Param("dayOfWeek") DayOfWeek dayOfWeek,
+            @Param("pStartTime") LocalTime pStartTime,
+            @Param("pEndTime") LocalTime pEndTime,
+            @Param("courseId") Long courseId);
 }

--- a/backend/src/test/java/com/WEB4_5_GPT_BE/unihub/domain/course/service/CourseServiceTest.java
+++ b/backend/src/test/java/com/WEB4_5_GPT_BE/unihub/domain/course/service/CourseServiceTest.java
@@ -13,7 +13,6 @@ import com.WEB4_5_GPT_BE.unihub.domain.course.repository.CourseScheduleRepositor
 import com.WEB4_5_GPT_BE.unihub.domain.member.entity.Member;
 import com.WEB4_5_GPT_BE.unihub.domain.member.entity.ProfessorProfile;
 import com.WEB4_5_GPT_BE.unihub.domain.member.repository.ProfessorProfileRepository;
-import com.WEB4_5_GPT_BE.unihub.domain.member.repository.StudentProfileRepository;
 import com.WEB4_5_GPT_BE.unihub.domain.university.entity.Major;
 import com.WEB4_5_GPT_BE.unihub.domain.university.entity.University;
 import com.WEB4_5_GPT_BE.unihub.domain.university.repository.MajorRepository;
@@ -56,9 +55,6 @@ class CourseServiceTest {
 
     @Mock
     private UniversityRepository universityRepository;
-
-    @Mock
-    private StudentProfileRepository studentProfileRepository;
 
     @Mock
     private ProfessorProfileRepository professorProfileRepository;
@@ -178,20 +174,21 @@ class CourseServiceTest {
         given(universityRepository.findByName(testUniversity1.getName())).willReturn(Optional.of(testUniversity1));
         given(majorRepository.findByUniversityIdAndName(testUniversity1.getId(), testCourseRequest3.major()))
                 .willReturn(Optional.of(testCourse2.getMajor()));
-        CourseScheduleDto csd = testCourseRequest3.schedule().getFirst();given(professorProfileRepository.findByUniversityIdAndEmployeeId(testUniversity1.getId(), testProfessorProfile1.getEmployeeId()))
+        CourseScheduleDto csd = testCourseRequest3.schedule().getFirst();
+        given(professorProfileRepository.findByUniversityIdAndEmployeeId(testUniversity1.getId(), testProfessorProfile1.getEmployeeId()))
                 .willReturn(Optional.of(testProfessorProfile1));
         given(courseScheduleRepository.existsByUnivIdAndLocationAndDayOfWeek(
-                    testUniversity1.getId(),
-                    testCourseRequest3.location(),
-                    csd.day(),
-                    LocalTime.parse(csd.startTime()),
-                    LocalTime.parse(csd.endTime())))
+                testUniversity1.getId(),
+                testCourseRequest3.location(),
+                csd.day(),
+                LocalTime.parse(csd.startTime()),
+                LocalTime.parse(csd.endTime())))
                 .willReturn(false);
         given(courseScheduleRepository.existsByProfEmpIdAndDayOfWeek(
-                    testProfessorProfile1.getEmployeeId(),
-                    csd.day(),
-                    LocalTime.parse(csd.startTime()),
-                    LocalTime.parse(csd.endTime())))
+                testProfessorProfile1.getEmployeeId(),
+                csd.day(),
+                LocalTime.parse(csd.startTime()),
+                LocalTime.parse(csd.endTime())))
                 .willReturn(false);
         given(courseRepository.save(any(Course.class))).willReturn(testCourseRequest3.toEntity(testMajor2, 0, testProfessorProfile1));
 
@@ -246,7 +243,8 @@ class CourseServiceTest {
         given(universityRepository.findByName(testUniversity1.getName())).willReturn(Optional.of(testUniversity1));
         given(majorRepository.findByUniversityIdAndName(testUniversity1.getId(), testCourseRequest2.major()))
                 .willReturn(Optional.of(testCourse2.getMajor()));
-        CourseScheduleDto csd = testCourseRequest2.schedule().getFirst();given(professorProfileRepository.findByUniversityIdAndEmployeeId(testUniversity1.getId(), testProfessorProfile1.getEmployeeId()))
+        CourseScheduleDto csd = testCourseRequest2.schedule().getFirst();
+        given(professorProfileRepository.findByUniversityIdAndEmployeeId(testUniversity1.getId(), testProfessorProfile1.getEmployeeId()))
                 .willReturn(Optional.of(testProfessorProfile1));
         given(courseScheduleRepository.existsByProfEmpIdAndDayOfWeek(
                 testCourseRequest2.employeeId(),
@@ -316,18 +314,20 @@ class CourseServiceTest {
         given(professorProfileRepository.findByUniversityIdAndEmployeeId(testUniversity1.getId(), testProfessorProfile1.getEmployeeId()))
                 .willReturn(Optional.of(testProfessorProfile1));
         CourseScheduleDto csd = testCourseRequest3.schedule().getFirst();
-        given(courseScheduleRepository.existsByUnivIdAndLocationAndDayOfWeek(
+        given(courseScheduleRepository.existsByUnivIdAndLocationAndDayOfWeekExcludingCourse(
                 testUniversity1.getId(),
                 testCourseRequest3.location(),
                 csd.day(),
                 LocalTime.parse(csd.startTime()),
-                LocalTime.parse(csd.endTime())))
+                LocalTime.parse(csd.endTime()),
+                1L))
                 .willReturn(false);
-        given(courseScheduleRepository.existsByProfEmpIdAndDayOfWeek(
+        given(courseScheduleRepository.existsByProfEmpIdAndDayOfWeekExcludingCourse(
                 testProfessorProfile1.getEmployeeId(),
                 csd.day(),
                 LocalTime.parse(csd.startTime()),
-                LocalTime.parse(csd.endTime())))
+                LocalTime.parse(csd.endTime()),
+                1L))
                 .willReturn(false);
         given(courseRepository.save(any(Course.class))).willReturn(testCourseRequest3.toEntity(testMajor2, 0, testProfessorProfile1));
 
@@ -339,12 +339,21 @@ class CourseServiceTest {
         then(courseRepository).should().findById(1L);
         then(universityRepository).should().findByName(testUniversity1.getName());
         then(majorRepository).should().findByUniversityIdAndName(testUniversity1.getId(), testCourseRequest3.major());
-        then(courseScheduleRepository).should().existsByUnivIdAndLocationAndDayOfWeek(
+        then(professorProfileRepository).should().findByUniversityIdAndEmployeeId(testUniversity1.getId(), testProfessorProfile1.getEmployeeId());
+        then(courseScheduleRepository).should().existsByUnivIdAndLocationAndDayOfWeekExcludingCourse(
                 testUniversity1.getId(),
                 testCourseRequest3.location(),
                 csd.day(),
                 LocalTime.parse(csd.startTime()),
-                LocalTime.parse(csd.endTime()));
+                LocalTime.parse(csd.endTime()),
+                1L);
+        then(courseScheduleRepository).should().existsByProfEmpIdAndDayOfWeekExcludingCourse(
+                testProfessorProfile1.getEmployeeId(),
+                csd.day(),
+                LocalTime.parse(csd.startTime()),
+                LocalTime.parse(csd.endTime()),
+                1L);
+        then(courseRepository).should().save(any(Course.class));
     }
 
     @Test
@@ -355,12 +364,13 @@ class CourseServiceTest {
         given(majorRepository.findByUniversityIdAndName(testUniversity1.getId(), testCourseRequest1.major()))
                 .willReturn(Optional.of(testCourse2.getMajor()));
         CourseScheduleDto csd = testCourseRequest1.schedule().getFirst();
-        given(courseScheduleRepository.existsByUnivIdAndLocationAndDayOfWeek(
+        given(courseScheduleRepository.existsByUnivIdAndLocationAndDayOfWeekExcludingCourse(
                 testUniversity1.getId(),
                 testCourseRequest1.location(),
                 csd.day(),
                 LocalTime.parse(csd.startTime()),
-                LocalTime.parse(csd.endTime())))
+                LocalTime.parse(csd.endTime()),
+                testCourse1.getId()))
                 .willReturn(true);
 
         Throwable result = catchThrowable(() -> courseService.updateCourse(testCourse1.getId(), testCourseRequest1));
@@ -368,14 +378,16 @@ class CourseServiceTest {
         assertThat(result)
                 .isInstanceOf(UnihubException.class)
                 .hasMessage("강의 장소가 이미 사용 중입니다.");
+        then(courseRepository).should().findById(testCourse1.getId());
         then(universityRepository).should().findByName(testUniversity1.getName());
         then(majorRepository).should().findByUniversityIdAndName(testUniversity1.getId(), testCourseRequest1.major());
-        then(courseScheduleRepository).should().existsByUnivIdAndLocationAndDayOfWeek(
+        then(courseScheduleRepository).should().existsByUnivIdAndLocationAndDayOfWeekExcludingCourse(
                 testUniversity1.getId(),
                 testCourseRequest1.location(),
                 csd.day(),
                 LocalTime.parse(csd.startTime()),
-                LocalTime.parse(csd.endTime()));
+                LocalTime.parse(csd.endTime()),
+                testCourse1.getId());
     }
 
     @Test
@@ -385,28 +397,31 @@ class CourseServiceTest {
         given(universityRepository.findByName(testUniversity1.getName())).willReturn(Optional.of(testUniversity1));
         given(majorRepository.findByUniversityIdAndName(testUniversity1.getId(), testCourseRequest2.major()))
                 .willReturn(Optional.of(testCourse2.getMajor()));
-        CourseScheduleDto csd = testCourseRequest2.schedule().getFirst();given(professorProfileRepository.findByUniversityIdAndEmployeeId(testUniversity1.getId(), testProfessorProfile1.getEmployeeId()))
+        CourseScheduleDto csd = testCourseRequest2.schedule().getFirst();
+        given(professorProfileRepository.findByUniversityIdAndEmployeeId(testUniversity1.getId(), testProfessorProfile1.getEmployeeId()))
                 .willReturn(Optional.of(testProfessorProfile1));
-        given(courseScheduleRepository.existsByProfEmpIdAndDayOfWeek(
+        given(courseScheduleRepository.existsByProfEmpIdAndDayOfWeekExcludingCourse(
                 testCourseRequest2.employeeId(),
                 csd.day(),
                 LocalTime.parse(csd.startTime()),
-                LocalTime.parse(csd.endTime())))
+                LocalTime.parse(csd.endTime()),
+                testCourse1.getId()))
                 .willReturn(true);
-
 
         Throwable result = catchThrowable(() -> courseService.updateCourse(testCourse1.getId(), testCourseRequest2));
 
         assertThat(result)
                 .isInstanceOf(UnihubException.class)
                 .hasMessage("강사/교수가 이미 수업 중입니다.");
+        then(courseRepository).should().findById(testCourse1.getId());
         then(universityRepository).should().findByName(testUniversity1.getName());
         then(majorRepository).should().findByUniversityIdAndName(testUniversity1.getId(), testCourseRequest1.major());
-        then(courseScheduleRepository).should().existsByProfEmpIdAndDayOfWeek(
+        then(courseScheduleRepository).should().existsByProfEmpIdAndDayOfWeekExcludingCourse(
                 testCourseRequest2.employeeId(),
                 csd.day(),
                 LocalTime.parse(csd.startTime()),
-                LocalTime.parse(csd.endTime()));
+                LocalTime.parse(csd.endTime()),
+                testCourse1.getId());
     }
 
     // 나머지 2가지 검색 타입에 대한 테스트 생략


### PR DESCRIPTION
## ✨ 변경 사항 설명
`CourseScheduleRepository`에 특정 강의를 제외한 스케줄 조회를 지원하는 쿼리 메소드 추가.
`CourseService`에서 강의 수정시 기존 스케줄을 제외한 상태에서 `CourseRequest`에 담긴 스케줄을 검증하도록 수정.
변경 내용을 테스트에 반영.

## ✅ 체크리스트

<!-- 📝 완료된 항목은 [x]로 표시해주세요. -->

- [x] 🏗️ 코드가 **코딩 스타일 가이드**를 준수합니다.
- [x] 🧪 변경 사항에 대한 **테스트가 추가**되었습니다.
- [x] ✅ 모든 **테스트가 정상적으로 통과**합니다.
- [x] 📚 필요한 **문서가 업데이트**되었습니다.

Closes #91.