### PR TITLE
로그인시 refreshToken을 Reponse에서 제거, refreshToken의 저장기간을 1일로 변경

### DIFF
--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/member/dto/response/AdminLoginResponse.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/member/dto/response/AdminLoginResponse.java
@@ -2,4 +2,4 @@ package com.WEB4_5_GPT_BE.unihub.domain.member.dto.response;
 
 import com.WEB4_5_GPT_BE.unihub.domain.common.enums.Role;
 
-public record AdminLoginResponse(String accessToken, String refreshToken, Long id, String email, Role role) {}
+public record AdminLoginResponse(String accessToken, Long id, String email, Role role) {}

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/member/dto/response/MemberLoginResponse.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/member/dto/response/MemberLoginResponse.java
@@ -2,4 +2,4 @@ package com.WEB4_5_GPT_BE.unihub.domain.member.dto.response;
 
 import com.WEB4_5_GPT_BE.unihub.domain.common.enums.Role;
 
-public record MemberLoginResponse(String accessToken, String refreshToken, Long id, String email, Role role) {}
+public record MemberLoginResponse(String accessToken, Long id, String email, Role role) {}

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/member/service/AuthServiceImpl.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/member/service/AuthServiceImpl.java
@@ -37,7 +37,7 @@ public class AuthServiceImpl implements AuthService {
   private static final String LOGIN_FAIL_PREFIX = "login:fail:";
   private static final int MAX_FAIL_COUNT = 5;
   private static final Duration LOCK_DURATION = Duration.ofMinutes(5);
-  private static final Duration REFRESH_TOKEN_DURATION = Duration.ofDays(7);
+  private static final Duration REFRESH_TOKEN_DURATION = Duration.ofDays(1);
 
   @Override
   @Transactional
@@ -120,12 +120,12 @@ public class AuthServiceImpl implements AuthService {
     String refreshToken = authTokenService.genRefreshToken(member.getId());
     saveRefreshToken(member.getId(), refreshToken);
     rq.addCookie("refreshToken", refreshToken, REFRESH_TOKEN_DURATION);
-    return new MemberLoginResponse(accessToken, refreshToken, member.getId(), member.getEmail(), member.getRole());
+    return new MemberLoginResponse(accessToken, member.getId(), member.getEmail(), member.getRole());
   }
 
   private AdminLoginResponse toAdminLoginResponse(Member member) {
     MemberLoginResponse base = toMemberLoginResponse(member);
-    return new AdminLoginResponse(base.accessToken(), base.refreshToken(), member.getId(), member.getEmail(), member.getRole());
+    return new AdminLoginResponse(base.accessToken(), member.getId(), member.getEmail(), member.getRole());
   }
 
   private void saveRefreshToken(Long memberId, String refreshToken) {
@@ -166,6 +166,6 @@ public class AuthServiceImpl implements AuthService {
             .orElseThrow(MemberNotFoundException::new);
 
     String newAccessToken = authTokenService.genAccessToken(member);
-    return new MemberLoginResponse(newAccessToken, null, member.getId(), member.getEmail(), member.getRole());
+    return new MemberLoginResponse(newAccessToken, member.getId(), member.getEmail(), member.getRole());
   }
 }

--- a/backend/src/test/java/com/WEB4_5_GPT_BE/unihub/domain/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/WEB4_5_GPT_BE/unihub/domain/member/controller/MemberControllerTest.java
@@ -5,11 +5,15 @@ import com.WEB4_5_GPT_BE.unihub.domain.member.dto.request.MemberLoginRequest;
 import com.WEB4_5_GPT_BE.unihub.domain.member.dto.request.PasswordResetConfirmationRequest;
 import com.WEB4_5_GPT_BE.unihub.domain.member.dto.request.ProfessorSignUpRequest;
 import com.WEB4_5_GPT_BE.unihub.domain.member.dto.request.StudentSignUpRequest;
-import com.WEB4_5_GPT_BE.unihub.domain.member.dto.request.mypage.*;
+import com.WEB4_5_GPT_BE.unihub.domain.member.dto.request.mypage.UpdateEmailRequest;
+import com.WEB4_5_GPT_BE.unihub.domain.member.dto.request.mypage.UpdateMajorRequest;
+import com.WEB4_5_GPT_BE.unihub.domain.member.dto.request.mypage.UpdatePasswordRequest;
+import com.WEB4_5_GPT_BE.unihub.domain.member.dto.request.mypage.VerifyPasswordRequest;
 import com.WEB4_5_GPT_BE.unihub.domain.member.service.EmailService;
 import com.WEB4_5_GPT_BE.unihub.global.config.RedisTestContainerConfig;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.Cookie;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,16 +22,19 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
 @Transactional
@@ -95,7 +102,7 @@ public class MemberControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("로그인에 성공했습니다."))
                 .andExpect(jsonPath("$.data.accessToken").exists())
-                .andExpect(jsonPath("$.data.refreshToken").exists());
+                .andExpect(header().string("Set-Cookie", Matchers.containsString("refreshToken=")));;
     }
 
     @Test
@@ -120,14 +127,23 @@ public class MemberControllerTest {
     void refreshToken_success() throws Exception {
         MemberLoginRequest loginRequest = new MemberLoginRequest("teststudent@auni.ac.kr", "password");
 
-        String loginResponse = mockMvc.perform(post("/api/members/login")
+        MockHttpServletResponse loginResponse = mockMvc.perform(post("/api/members/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(loginRequest)))
-                .andReturn().getResponse().getContentAsString();
+                .andReturn()
+                .getResponse();
 
-        String refreshToken = objectMapper.readTree(loginResponse).path("data").path("refreshToken").asText();
+        Cookie refreshTokenCookie = Arrays.stream(loginResponse.getCookies())
+                .filter(cookie -> "refreshToken".equals(cookie.getName()))
+                .findFirst()
+                .orElse(null);
 
-        mockMvc.perform(post("/api/members/refresh").cookie(new Cookie("refreshToken", refreshToken)))
+        assertThat(refreshTokenCookie)
+                .as("refreshToken 쿠키가 응답에 포함되어야 합니다.")
+                .isNotNull();
+
+        mockMvc.perform(post("/api/members/refresh")
+                        .cookie(refreshTokenCookie))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("새로운 토큰이 발급되었습니다."))
                 .andExpect(jsonPath("$.data.accessToken").exists());


### PR DESCRIPTION
## ✨ 변경 사항 설명

로그인시 refreshToken을 Reponse에서 제거
refreshToken의 저장기간을 1일로 .yml과 동일하게 변경

## ✅ 체크리스트

<!-- 📝 완료된 항목은 [x]로 표시해주세요. -->

- [x] 🏗️ 코드가 **코딩 스타일 가이드**를 준수합니다.
- [x] 🧪 변경 사항에 대한 **테스트가 추가**되었습니다.
- [x] ✅ 모든 **테스트가 정상적으로 통과**합니다.
- [ ] 📚 필요한 **문서가 업데이트**되었습니다.

## 🎨 스크린샷 (UI 변경이 있는 경우)

<!-- 🖼️ 변경 전/후 스크린샷을 추가해주세요. -->

## 🛠️ 테스트 방법 (필요시)

<!-- 🧑‍💻 이 PR을 테스트하는 방법을 설명해주세요. -->
