### PR TITLE
Merge develop into main: 초기 데이터 설정, 로그인 response 수정, 강의 필터링 기능, 수강신청 기간 조회 개발

### DIFF
--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/admin/controller/AdminController.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/admin/controller/AdminController.java
@@ -5,6 +5,12 @@ import com.WEB4_5_GPT_BE.unihub.domain.admin.dto.response.EnrollmentPeriodRespon
 import com.WEB4_5_GPT_BE.unihub.domain.admin.dto.response.ProfessorResponse;
 import com.WEB4_5_GPT_BE.unihub.domain.admin.dto.response.StudentResponse;
 import com.WEB4_5_GPT_BE.unihub.domain.admin.service.AdminService;
+import com.WEB4_5_GPT_BE.unihub.domain.university.dto.request.MajorRequest;
+import com.WEB4_5_GPT_BE.unihub.domain.university.dto.request.UniversityRequest;
+import com.WEB4_5_GPT_BE.unihub.domain.university.dto.response.MajorResponse;
+import com.WEB4_5_GPT_BE.unihub.domain.university.dto.response.UniversityResponse;
+import com.WEB4_5_GPT_BE.unihub.domain.university.service.MajorService;
+import com.WEB4_5_GPT_BE.unihub.domain.university.service.UniversityService;
 import com.WEB4_5_GPT_BE.unihub.global.response.RsData;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -24,6 +30,8 @@ import org.springframework.web.bind.annotation.*;
 public class AdminController {
 
     private final AdminService adminService;
+    private final UniversityService universityService;
+    private final MajorService majorService;
 
     @Operation(summary = "학생 회원 목록 조회", description = "다양한 조건으로 학생 회원 목록을 조회합니다.")
     @ApiResponses(value = {
@@ -161,7 +169,95 @@ public class AdminController {
   })
   @PostMapping("/invite")
   public RsData<Void> inviteAdmin(@RequestBody AdminInviteRequest request) {
-    adminService.inviteAdmin(request);
-    return new RsData<>("200", "관리자 초대가 완료되었습니다.");
+      adminService.inviteAdmin(request);
+      return new RsData<>("200", "관리자 초대가 완료되었습니다.");
   }
+
+    // 대학 관리 API
+    @Operation(summary = "대학 생성", description = "새로운 대학을 등록합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "대학 등록 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "403", description = "관리자 권한이 없음"),
+            @ApiResponse(responseCode = "409", description = "이미 존재하는 대학 이름 또는 이메일 도메인")
+    })
+    @PostMapping("/universities")
+    public RsData<UniversityResponse> createUniversity(@RequestBody UniversityRequest request) {
+        UniversityResponse university = universityService.createUniversity(request);
+        return new RsData<>("201", "대학이 등록되었습니다.", university);
+    }
+
+    @Operation(summary = "대학 수정", description = "대학 정보를 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "대학 수정 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "403", description = "관리자 권한이 없음"),
+            @ApiResponse(responseCode = "404", description = "대학을 찾을 수 없음"),
+            @ApiResponse(responseCode = "409", description = "이미 존재하는 대학 이름 또는 이메일 도메인")
+    })
+    @PutMapping("/universities/{universityId}")
+    public RsData<UniversityResponse> updateUniversity(
+            @PathVariable Long universityId, @RequestBody UniversityRequest request) {
+        UniversityResponse university = universityService.updateUniversity(universityId, request);
+        return new RsData<>("200", "대학 정보가 수정되었습니다.", university);
+    }
+
+    @Operation(summary = "대학 삭제", description = "대학을 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "대학 삭제 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "403", description = "관리자 권한이 없음"),
+            @ApiResponse(responseCode = "404", description = "대학을 찾을 수 없음")
+    })
+    @DeleteMapping("/universities/{universityId}")
+    public RsData<Void> deleteUniversity(@PathVariable Long universityId) {
+        universityService.deleteUniversity(universityId);
+        return new RsData<>("200", "대학이 삭제되었습니다.");
+    }
+
+    // 전공 관리 API
+    @Operation(summary = "전공 생성", description = "새로운 전공을 등록합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "전공 등록 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "403", description = "관리자 권한이 없음"),
+            @ApiResponse(responseCode = "409", description = "이미 존재하는 전공 이름")
+    })
+    @PostMapping("/majors")
+    public RsData<MajorResponse> createMajor(@RequestBody MajorRequest request) {
+        MajorResponse major = majorService.createMajor(request);
+        return new RsData<>("201", "전공이 등록되었습니다.", major);
+    }
+
+    @Operation(summary = "전공 수정", description = "전공 정보를 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "전공 수정 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "403", description = "관리자 권한이 없음"),
+            @ApiResponse(responseCode = "404", description = "전공을 찾을 수 없음"),
+            @ApiResponse(responseCode = "409", description = "이미 존재하는 전공 이름")
+    })
+    @PutMapping("/majors/{majorId}")
+    public RsData<MajorResponse> updateMajor(
+            @PathVariable Long majorId, @RequestBody MajorRequest request) {
+        MajorResponse major = majorService.updateMajor(majorId, request);
+        return new RsData<>("200", "전공 정보가 수정되었습니다.", major);
+    }
+
+    @Operation(summary = "전공 삭제", description = "전공을 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "전공 삭제 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "403", description = "관리자 권한이 없음"),
+            @ApiResponse(responseCode = "404", description = "전공을 찾을 수 없음")
+    })
+    @DeleteMapping("/majors/{majorId}")
+    public RsData<Void> deleteMajor(@PathVariable Long majorId) {
+        majorService.deleteMajor(majorId);
+        return new RsData<>("200", "전공이 삭제되었습니다.");
+    }
 }

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/admin/controller/AdminController.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/admin/controller/AdminController.java
@@ -20,13 +20,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Admin", description = "관리자 관련 API (학생/교수 관리, 수강신청 기간 관리, 관리자 초대 등)")
 @RestController
 @RequestMapping("/api/admin")
 @RequiredArgsConstructor
-//@PreAuthorize("hasRole('ADMIN')")
+@PreAuthorize("hasRole('ADMIN')")
 public class AdminController {
 
     private final AdminService adminService;

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/course/controller/CourseController.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/course/controller/CourseController.java
@@ -133,6 +133,12 @@ public class CourseController {
         @RequestParam(name = "title", defaultValue = "") String title,
         @Parameter(description = "강사/교수 이름 검색 키워드")
         @RequestParam(name = "profName", defaultValue = "") String profName,
+
+        // 추가된 필터링 파라미터
+        @Parameter(description = "전공 ID") @RequestParam(required = false) Long majorId,
+        @Parameter(description = "학년") @RequestParam(required = false) Integer grade,
+        @Parameter(description = "학기") @RequestParam(required = false) Integer semester,
+
         @AuthenticationPrincipal SecurityUser principal,
         @Parameter(hidden = true)
         @PageableDefault @ParameterObject Pageable pageable) {
@@ -143,13 +149,13 @@ public class CourseController {
         return switch (mode) {
             case FULL -> new RsData<>(String.valueOf(HttpStatus.OK.value()),
                     "조회에 성공했습니다.",
-                    courseService.findAllCoursesModeFull(title, profName, principal, pageable));
+                    courseService.findAllCoursesModeFull(title, profName, majorId, grade, semester, principal, pageable));
             case ENROLL -> new RsData<>(String.valueOf(HttpStatus.OK.value()),
                     "조회에 성공했습니다.",
-                    courseService.findAllCoursesModeEnroll(title, profName, principal, pageable));
+                    courseService.findAllCoursesModeEnroll(title, profName, majorId, grade, semester, principal, pageable));
             case CATALOG -> new RsData<>(String.valueOf(HttpStatus.OK.value()),
                     "조회에 성공했습니다.",
-                    courseService.findAllCoursesModeCatalog(title, profName, principal, pageable));
+                    courseService.findAllCoursesModeCatalog(title, profName, majorId, grade, semester, principal, pageable));
         };
     }
 }

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/course/repository/CourseRepository.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/course/repository/CourseRepository.java
@@ -28,12 +28,19 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
         WHERE mj.university.id = :univId
             AND c.title LIKE CONCAT('%', :title, '%')
             AND COALESCE(me.name, "") LIKE CONCAT('%', :profName, '%')
+            AND (:majorId IS NULL OR mj.id = :majorId)
+            AND (:grade IS NULL OR c.grade = :grade)
+            AND (:semester IS NULL OR c.semester = :semester)
     """)
-    Page<Course> findByTitleLikeAndProfessorNameLike(
+    Page<Course> findWithFilters(
             @Param("univId") Long univId,
             @Param("title") String title,
             @Param("profName") String profName,
-            Pageable pageable);
+            @Param("majorId") Long majorId,
+            @Param("grade") Integer grade,
+            @Param("semester") Integer semester,
+            Pageable pageable
+    );
 
     List<Course> findByProfessorId(Long professorId);
 }

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/course/service/CourseService.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/course/service/CourseService.java
@@ -135,9 +135,13 @@ public class CourseService {
      * @return 조회된 강의에 해당하는 {@link CourseWithFullScheduleResponse} DTO가 담긴 {@link Page} 오브젝트
      */
     // TODO: 응답 DTO가 레코드로 구현되어 있어 조회 타입마다 메소드를 구현했는데, 구현체를 일반 클래스로 바꿔 공통 필드를 상속받게 변경할지를 고려해 볼 것.
-    public Page<CourseWithFullScheduleResponse> findAllCoursesModeFull(String title, String profName, SecurityUser principal, Pageable pageable) {
-        Long authUserUnivId = getUnivIdFromPrincipal(principal);
-        return courseRepository.findByTitleLikeAndProfessorNameLike(authUserUnivId, title, profName, pageable).map(CourseWithFullScheduleResponse::from);
+    public Page<CourseWithFullScheduleResponse> findAllCoursesModeFull(
+            String title, String profName, Long majorId, Integer grade, Integer semester,
+            SecurityUser principal, Pageable pageable) {
+        Long universityId = getUnivIdFromPrincipal(principal);
+        return courseRepository
+                .findWithFilters(universityId, title, profName, majorId, grade, semester, pageable)
+                .map(CourseWithFullScheduleResponse::from);
     }
 
     /**
@@ -148,9 +152,14 @@ public class CourseService {
      * @param pageable 페이지네이션 정보
      * @return 조회된 강의에 해당하는 {@link CourseEnrollmentResponse} DTO가 담긴 {@link Page} 오브젝트
      */
-    public Page<CourseEnrollmentResponse> findAllCoursesModeEnroll(String title, String profName, SecurityUser principal, Pageable pageable) {
+    public Page<CourseEnrollmentResponse> findAllCoursesModeEnroll(
+            String title, String profName, Long majorId, Integer grade, Integer semester,
+            SecurityUser principal, Pageable pageable) {
+
         Long authUserUnivId = getUnivIdFromPrincipal(principal);
-        return courseRepository.findByTitleLikeAndProfessorNameLike(authUserUnivId, title, profName, pageable).map(CourseEnrollmentResponse::from);
+        return courseRepository
+                .findWithFilters(authUserUnivId, title, profName, majorId, grade, semester, pageable)
+                .map(CourseEnrollmentResponse::from);
     }
 
     /**
@@ -161,9 +170,14 @@ public class CourseService {
      * @param pageable 페이지네이션 정보
      * @return 조회된 강의에 해당하는 {@link CourseResponse} DTO가 담긴 {@link Page} 오브젝트
      */
-    public Page<CourseResponse> findAllCoursesModeCatalog(String title, String profName, SecurityUser principal, Pageable pageable) {
+    public Page<CourseResponse> findAllCoursesModeCatalog(
+            String title, String profName, Long majorId, Integer grade, Integer semester,
+            SecurityUser principal, Pageable pageable) {
+
         Long authUserUnivId = getUnivIdFromPrincipal(principal);
-        return courseRepository.findByTitleLikeAndProfessorNameLike(authUserUnivId, title, profName, pageable).map(CourseResponse::from);
+        return courseRepository
+                .findWithFilters(authUserUnivId, title, profName, majorId, grade, semester, pageable)
+                .map(CourseResponse::from);
     }
 
     /**

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/controller/EnrollmentController.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/controller/EnrollmentController.java
@@ -3,11 +3,13 @@ package com.WEB4_5_GPT_BE.unihub.domain.enrollment.controller;
 import com.WEB4_5_GPT_BE.unihub.domain.course.exception.CourseNotFoundException;
 import com.WEB4_5_GPT_BE.unihub.domain.enrollment.dto.request.EnrollmentRequest;
 import com.WEB4_5_GPT_BE.unihub.domain.enrollment.dto.response.MyEnrollmentResponse;
+import com.WEB4_5_GPT_BE.unihub.domain.enrollment.dto.response.StudentEnrollmentPeriodResponse;
 import com.WEB4_5_GPT_BE.unihub.domain.enrollment.exception.*;
 import com.WEB4_5_GPT_BE.unihub.domain.enrollment.service.EnrollmentService;
 import com.WEB4_5_GPT_BE.unihub.domain.enrollment.springDoc.apiResponse.EnrollmentApiResponse;
 import com.WEB4_5_GPT_BE.unihub.domain.enrollment.springDoc.apiResponse.EnrollmentCancelApiResponse;
 import com.WEB4_5_GPT_BE.unihub.domain.enrollment.springDoc.apiResponse.GetMyEnrollmentListApiResponse;
+import com.WEB4_5_GPT_BE.unihub.domain.enrollment.springDoc.apiResponse.getMyEnrollmentPeriodApiResponse;
 import com.WEB4_5_GPT_BE.unihub.domain.member.entity.Member;
 import com.WEB4_5_GPT_BE.unihub.global.Rq;
 import com.WEB4_5_GPT_BE.unihub.global.response.Empty;
@@ -50,12 +52,21 @@ public class EnrollmentController {
     public RsData<List<MyEnrollmentResponse>> getMyEnrollmentList() {
 
         Member actor = rq.getActor(); // 인증된 사용자(Actor) 정보 획득
-        Member student = rq.getRealActor(actor); // 실제 학생(Member) 객체 얻기 (StudentProfile 필요)
-
-        // 내 수강목록을 조회하여 반환
-        List<MyEnrollmentResponse> response = enrollmentService.getMyEnrollmentList(student);
+        List<MyEnrollmentResponse> response = enrollmentService.getMyEnrollmentList(actor); // 내 수강목록을 조회하여 반환
 
         return new RsData<>("200", "내 수강목록 조회가 완료되었습니다.", response);
+    }
+
+    @Operation(summary = "내 수강신청 기간 조회",
+            description = "로그인된 학생의 수강신청 기간 정보를 조회합니다. header에 Bearer accessToken이 없다면 접근할 수 없습니다.")
+    @getMyEnrollmentPeriodApiResponse // api 요청에 대한 성공,예외 response 예시를 정의합니다.
+    @GetMapping("/periods/me")
+    public RsData<StudentEnrollmentPeriodResponse> getMyEnrollmentPeriod() {
+
+        Member actor = rq.getActor(); // 인증된 사용자(Actor) 정보 획득
+        StudentEnrollmentPeriodResponse response = enrollmentService.getMyEnrollmentPeriod(actor); // 내 수강신청 기간 정보 조회
+
+        return new RsData<>("200", "내 수강신청 기간 정보를 조회했습니다.", response);
     }
 
     /**
@@ -76,10 +87,7 @@ public class EnrollmentController {
     public RsData<Empty> enrollmentCancel(@PathVariable Long courseId) {
 
         Member actor = rq.getActor(); // 인증된 사용자(Actor) 정보 획득
-        Member student = rq.getRealActor(actor); // 실제 학생(Member) 객체 얻기 (StudentProfile 필요)
-
-        // 해당 강좌에 대한 수강 취소 요청
-        enrollmentService.cancelMyEnrollment(student, courseId);
+        enrollmentService.cancelMyEnrollment(actor, courseId); // 해당 강좌에 대한 수강 취소 요청
 
         return new RsData<>("200", "수강 취소가 완료되었습니다.");
     }
@@ -106,10 +114,7 @@ public class EnrollmentController {
     public RsData<Empty> enrollment(@RequestBody EnrollmentRequest request) {
 
         Member actor = rq.getActor(); // 인증된 사용자(Actor) 정보 획득
-        Member student = rq.getRealActor(actor); // 실제 학생(Member) 객체 얻기 (StudentProfile 필요)
-
-        // 해당 강좌에 대한 수강 신청 요청
-        enrollmentService.enrollment(student, request.courseId());
+        enrollmentService.enrollment(actor, request.courseId()); // 해당 강좌에 대한 수강 신청 요청
 
         return new RsData<>("200", "수강 신청이 완료되었습니다.");
     }

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/controller/EnrollmentEventController.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/controller/EnrollmentEventController.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,7 +24,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @Tag(name = "Enrollment", description = "수강신청 관련 API (대기열 관리, 이벤트 스트림 등)")
 @Slf4j
 @RestController
-@RequestMapping("/api/enrollment")
+@RequestMapping("/api/enrollments")
 @RequiredArgsConstructor
 public class EnrollmentEventController {
 
@@ -36,7 +37,7 @@ public class EnrollmentEventController {
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
     })
     @GetMapping(value = "/events", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter subscribeToEvents(SecurityUser securityUser) {
+    public SseEmitter subscribeToEvents(@AuthenticationPrincipal SecurityUser securityUser) {
         // 인증된 사용자 정보가 없는 경우 예외 처리
         if (securityUser == null) {
             log.warn("인증되지 않은 SSE 연결 시도");
@@ -59,7 +60,7 @@ public class EnrollmentEventController {
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
     })
     @PostMapping("/queue/join")
-    public RsData<QueueStatusDto> joinQueue(SecurityUser securityUser) {
+    public RsData<QueueStatusDto> joinQueue(@AuthenticationPrincipal SecurityUser securityUser) {
         if (securityUser == null) {
             throw new UnihubException("401", "인증되지 않은 요청입니다.");
         }
@@ -74,7 +75,7 @@ public class EnrollmentEventController {
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
     })
     @GetMapping("/queue/status")
-    public RsData<QueueStatusDto> getQueueStatus(SecurityUser securityUser) {
+    public RsData<QueueStatusDto> getQueueStatus(@AuthenticationPrincipal SecurityUser securityUser) {
         if (securityUser == null) {
             throw new UnihubException("401", "인증되지 않은 요청입니다.");
         }
@@ -89,7 +90,7 @@ public class EnrollmentEventController {
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
     })
     @PostMapping("/queue/release")
-    public RsData<Empty> releaseSession(SecurityUser securityUser) {
+    public RsData<Empty> releaseSession(@AuthenticationPrincipal SecurityUser securityUser) {
         if (securityUser == null) {
             throw new UnihubException("401", "인증되지 않은 요청입니다.");
         }

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/dto/response/StudentEnrollmentPeriodResponse.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/dto/response/StudentEnrollmentPeriodResponse.java
@@ -1,0 +1,52 @@
+package com.WEB4_5_GPT_BE.unihub.domain.enrollment.dto.response;
+
+import com.WEB4_5_GPT_BE.unihub.domain.course.entity.EnrollmentPeriod;
+import com.WEB4_5_GPT_BE.unihub.domain.member.entity.StudentProfile;
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+/**
+ * 수강신청 기간 응답 DTO
+ */
+@Builder
+public record StudentEnrollmentPeriodResponse(
+        Long studentId,
+        String universityName,
+        Integer year,
+        Integer grade,
+        Integer semester,
+        LocalDate startDate,
+        LocalDate endDate,
+        Boolean isEnrollmentOpen
+) {
+
+    /**
+     * 수강신청 기간 응답 DTO 생성 (isEnrollmentOpen 포함 (수강신청 기간 내 요청 여부))
+     */
+    public static StudentEnrollmentPeriodResponse from(
+            EnrollmentPeriod period,
+            StudentProfile profile,
+            boolean isEnrollmentOpen
+    ) {
+        return StudentEnrollmentPeriodResponse.builder()
+                .studentId(profile.getId())
+                .universityName(profile.getUniversity().getName())
+                .year(period.getYear())
+                .grade(period.getGrade())
+                .semester(period.getSemester())
+                .startDate(period.getStartDate())
+                .endDate(period.getEndDate())
+                .isEnrollmentOpen(isEnrollmentOpen)
+                .build();
+    }
+
+    /**
+     * 기간이 repository에서 조회되지 않을 경우 사용
+     */
+    public static StudentEnrollmentPeriodResponse notOpen() {
+        return StudentEnrollmentPeriodResponse.builder()
+                .isEnrollmentOpen(false)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/springDoc/apiResponse/getMyEnrollmentPeriodApiResponse.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/springDoc/apiResponse/getMyEnrollmentPeriodApiResponse.java
@@ -1,0 +1,85 @@
+package com.WEB4_5_GPT_BE.unihub.domain.enrollment.springDoc.apiResponse;
+
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * 내 수강신청 기간 조회 API의 공통 응답 예시를 정의하는 메타 어노테이션입니다.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponses({
+        @ApiResponse(
+                responseCode = "200",
+                description = "내 수강신청 기간 정보를 조회하고 현재 해당기간에 포함되는지 확인합니다.",
+                content = @Content(
+                        examples = {
+                                @ExampleObject(
+                                        name = "수강신청 기간 존재 and 현재 열림",
+                                        value = """
+                                                {
+                                                  "code": "200",
+                                                  "message": "내 수강신청 기간 정보를 조회했습니다.",
+                                                  "data": {
+                                                    "studentId": 5,
+                                                    "universityName": "A대학교",
+                                                    "year": 2025,
+                                                    "grade": 1,
+                                                    "semester": 1,
+                                                    "startDate": "2025-05-01",
+                                                    "endDate": "2025-05-30",
+                                                    "isEnrollmentOpen": true
+                                                  }
+                                                }
+                                                """
+                                ),
+                                @ExampleObject(
+                                        name = "수강신청 기간 존재 but 현재 닫힘",
+                                        value = """
+                                                {
+                                                  "code": "200",
+                                                  "message": "내 수강신청 기간 정보를 조회했습니다.",
+                                                  "data": {
+                                                    "studentId": 5,
+                                                    "universityName": "A대학교",
+                                                    "year": 2025,
+                                                    "grade": 2,
+                                                    "semester": 1,
+                                                    "startDate": "2025-06-01",
+                                                    "endDate": "2025-06-30",
+                                                    "isEnrollmentOpen": false
+                                                  }
+                                                }
+                                                """
+                                ),
+                                @ExampleObject(
+                                        name = "수강신청 기간 정보 없음",
+                                        value = """
+                                                {
+                                                  "code": "200",
+                                                  "message": "내 수강신청 기간 정보를 조회했습니다.",
+                                                  "data": {
+                                                    "studentId": null,
+                                                    "universityName": null,
+                                                    "year": null,
+                                                    "grade": null,
+                                                    "semester": null,
+                                                    "startDate": null,
+                                                    "endDate": null,
+                                                    "isEnrollmentOpen": false
+                                                  }
+                                                }
+                                                """
+                                )
+                        }
+                )
+        )
+})
+public @interface getMyEnrollmentPeriodApiResponse {
+}

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/member/dto/response/AdminLoginResponse.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/member/dto/response/AdminLoginResponse.java
@@ -2,4 +2,4 @@ package com.WEB4_5_GPT_BE.unihub.domain.member.dto.response;
 
 import com.WEB4_5_GPT_BE.unihub.domain.common.enums.Role;
 
-public record AdminLoginResponse(String accessToken, String refreshToken, Long id, String email, Role role) {}
+public record AdminLoginResponse(String accessToken, Long id, String email, Role role) {}

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/member/dto/response/MemberLoginResponse.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/member/dto/response/MemberLoginResponse.java
@@ -2,4 +2,4 @@ package com.WEB4_5_GPT_BE.unihub.domain.member.dto.response;
 
 import com.WEB4_5_GPT_BE.unihub.domain.common.enums.Role;
 
-public record MemberLoginResponse(String accessToken, String refreshToken, Long id, String email, Role role) {}
+public record MemberLoginResponse(String accessToken, Long id, String email, Role role) {}

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/member/dto/response/mypage/ProfessorProfileResponse.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/member/dto/response/mypage/ProfessorProfileResponse.java
@@ -6,12 +6,14 @@ import lombok.Builder;
 @Builder
 public record ProfessorProfileResponse(
         String employeeId,
+        Long universityId,
         String university,
         String major
 ) {
     public static ProfessorProfileResponse from(ProfessorProfile profile) {
         return ProfessorProfileResponse.builder()
                 .employeeId(profile.getEmployeeId())
+                .universityId(profile.getUniversity().getId())
                 .university(profile.getUniversity().getName())
                 .major(profile.getMajor().getName())
                 .build();

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/member/dto/response/mypage/StudentProfileResponse.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/member/dto/response/mypage/StudentProfileResponse.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 @Builder
 public record StudentProfileResponse(
         String studentCode,
+        Long universityId,
         String university,
         String major,
         Integer grade,
@@ -14,6 +15,7 @@ public record StudentProfileResponse(
     public static StudentProfileResponse from(StudentProfile profile) {
         return StudentProfileResponse.builder()
                 .studentCode(profile.getStudentCode())
+                .universityId(profile.getUniversity().getId())
                 .university(profile.getUniversity().getName())
                 .major(profile.getMajor().getName())
                 .grade(profile.getGrade())

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/member/service/AuthServiceImpl.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/member/service/AuthServiceImpl.java
@@ -37,7 +37,7 @@ public class AuthServiceImpl implements AuthService {
   private static final String LOGIN_FAIL_PREFIX = "login:fail:";
   private static final int MAX_FAIL_COUNT = 5;
   private static final Duration LOCK_DURATION = Duration.ofMinutes(5);
-  private static final Duration REFRESH_TOKEN_DURATION = Duration.ofDays(7);
+  private static final Duration REFRESH_TOKEN_DURATION = Duration.ofDays(1);
 
   @Override
   @Transactional
@@ -120,12 +120,12 @@ public class AuthServiceImpl implements AuthService {
     String refreshToken = authTokenService.genRefreshToken(member.getId());
     saveRefreshToken(member.getId(), refreshToken);
     rq.addCookie("refreshToken", refreshToken, REFRESH_TOKEN_DURATION);
-    return new MemberLoginResponse(accessToken, refreshToken, member.getId(), member.getEmail(), member.getRole());
+    return new MemberLoginResponse(accessToken, member.getId(), member.getEmail(), member.getRole());
   }
 
   private AdminLoginResponse toAdminLoginResponse(Member member) {
     MemberLoginResponse base = toMemberLoginResponse(member);
-    return new AdminLoginResponse(base.accessToken(), base.refreshToken(), member.getId(), member.getEmail(), member.getRole());
+    return new AdminLoginResponse(base.accessToken(), member.getId(), member.getEmail(), member.getRole());
   }
 
   private void saveRefreshToken(Long memberId, String refreshToken) {
@@ -166,6 +166,6 @@ public class AuthServiceImpl implements AuthService {
             .orElseThrow(MemberNotFoundException::new);
 
     String newAccessToken = authTokenService.genAccessToken(member);
-    return new MemberLoginResponse(newAccessToken, null, member.getId(), member.getEmail(), member.getRole());
+    return new MemberLoginResponse(newAccessToken, member.getId(), member.getEmail(), member.getRole());
   }
 }

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/init/InitDataHelper.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/init/InitDataHelper.java
@@ -53,14 +53,9 @@ public class InitDataHelper {
         return majorRepository.save(Major.builder().name(name).university(university).build());
     }
 
-    public void createStudent(String email, String pw, String name, String studentCode, Long univId, Long majorId) {
+    public void createStudent(String email, String pw, String name, String studentCode, Long univId, Long majorId, Integer grade, Integer semester) {
         emailService.markEmailAsVerified(email);
-        memberService.signUpStudent(new StudentSignUpRequest(email, pw, name, studentCode, univId, majorId, 1, 1, Role.STUDENT));
-    }
-
-    public void create2ndStudent(String email, String pw, String name, String studentCode, Long univId, Long majorId) {
-        emailService.markEmailAsVerified(email);
-        memberService.signUpStudent(new StudentSignUpRequest(email, pw, name, studentCode, univId, majorId, 2, 1, Role.STUDENT));
+        memberService.signUpStudent(new StudentSignUpRequest(email, pw, name, studentCode, univId, majorId, grade, semester, Role.STUDENT));
     }
 
     public Course createCourse(String title, Major major, String location,

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/init/InitDevData.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/init/InitDevData.java
@@ -41,7 +41,7 @@ public class InitDevData {
         // 2) 1학년 학생·교수·관리자 계정 생성
         helper.createStudent(
                 "haneulkim@auni.ac.kr", "studentPw", "김하늘", "20250001",
-                university.getId(), majorSW.getId()
+                university.getId(), majorSW.getId(), 1, 1
         );
         Member professor1 = helper.createProfessor(
                 "professor1@auni.ac.kr", "password", "김교수", "EMP20250001",
@@ -70,9 +70,9 @@ public class InitDevData {
         helper.createEnrollment(student1, swCourses.get(1).getId());
 
         // 6) 2학년 학생 생성 (/api/members/signup/student)
-        helper.create2ndStudent(
+        helper.createStudent(
                 "secondstudent@auni.ac.kr", "studentPw2", "박학생", "20250002",
-                university.getId(), majorCS.getId()
+                university.getId(), majorCS.getId(), 2, 1
         );
         Member student2 = helper.getMemberByEmail("secondstudent@auni.ac.kr");
 

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/init/InitProdOrStgData.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/init/InitProdOrStgData.java
@@ -41,7 +41,7 @@ public class InitProdOrStgData {
         // 2) 1학년 학생·교수·관리자 계정 생성
         helper.createStudent(
                 "haneulkim@auni.ac.kr", "studentPw", "김하늘", "20250001",
-                university.getId(), majorSW.getId()
+                university.getId(), majorSW.getId(), 1, 1
         );
         Member professor1 = helper.createProfessor(
                 "professor1@auni.ac.kr", "password", "김교수", "EMP20250001",
@@ -70,9 +70,9 @@ public class InitProdOrStgData {
         helper.createEnrollment(student1, swCourses.get(1).getId());
 
         // 6) 2학년 학생 생성 (/api/members/signup/student)
-        helper.create2ndStudent(
+        helper.createStudent(
                 "secondstudent@auni.ac.kr", "studentPw2", "박학생", "20250002",
-                university.getId(), majorSW.getId()
+                university.getId(), majorSW.getId(), 2, 1
         );
         Member student2 = helper.getMemberByEmail("secondstudent@auni.ac.kr");
 

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/init/InitTestData.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/init/InitTestData.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 @Component
@@ -34,36 +35,128 @@ public class InitTestData {
         studentProfileRepository.deleteAll();
         helper.clearAllMemberData();
 
-        University university = helper.createUniversity("A대학교", "auni.ac.kr");
-        Major major = helper.createMajor("소프트웨어전공", university);
-        Major major2 = helper.createMajor("컴퓨터공학전공", university);
+        // 관리자 계정 생성 메서드
+        initAdmin();
 
-        helper.createStudent("teststudent@auni.ac.kr", "password", "테스트학생", "20250002",
-                university.getId(), major.getId());
+        List<University> universities = initUniversity();
+        University university = universities.get(0); // A대학교
 
-        helper.createStudent("teststudent2@auni.ac.kr", "password", "테스트학생2", "20250003",
-                university.getId(), major.getId());
+        List<Major> majors = initMajor(university);
+        Major major = majors.get(0); // 소프트웨어전공
 
-        helper.create2ndStudent("teststudent3@auni.ac.kr", "password", "테스트2학년학생1", "20250004",
-                university.getId(), major.getId());
+        // 학생 생성 메서드
+        initStudent(university, major);
 
-        // 승인된 교수 (로그인 성공용)
-        Member authenticatedProfessor = helper.createProfessor("professor@auni.ac.kr", "password", "김교수", "EMP00001",
-                university.getId(), major.getId(), ApprovalStatus.APPROVED);
+        // 교수 생성 메서드
+        List<Member> professors = initProfessor(university, major);
+        Member authenticatedProfessor = professors.get(0); // 승인된 교수
 
-        // 승인 안 된 교수 (로그인 실패용)
-        helper.createProfessor("pending@auni.ac.kr", "password", "대기중교수", "EMP00002",
-                university.getId(), major.getId(), ApprovalStatus.PENDING);
+        // 수강신청 기간 생성
+        initEnrollmentPeriod(university);
 
-        Course course = helper.createCourse("컴파일러", major, "공학관A", 200, 0, 4,
-                authenticatedProfessor.getProfessorProfile(), 4, 1, "/somePath/someAttachment.jpg");
+        // 테스트용 강좌 생성
+        List<Course> courses = initTestCourses(major, authenticatedProfessor.getProfessorProfile());
+
+        // 예외상황 강좌 생성
+        initConflictCourses(major, authenticatedProfessor.getProfessorProfile());
+
+        // ------- ↓초기화 이후 추가적인 작업↓ -------
+
+        Course compiler = courses.getFirst(); // 컴파일러
 
         for (DayOfWeek day : List.of(DayOfWeek.MON, DayOfWeek.TUE, DayOfWeek.WED)) {
-            helper.createCourseScheduleAndAssociateWithCourse(course, day, "12:00", "14:00");
+            helper.createCourseScheduleAndAssociateWithCourse(compiler, day, "12:00", "14:00");
         }
 
-        helper.createAdmin("adminmaster@auni.ac.kr", "adminPw", "관리자", passwordEncoder);
+        // 기존 생성되어있던 테스트학생에 2개의 수강신청 정보를 등록함
+        Member student = helper.getMemberByEmail("teststudent@auni.ac.kr");
+        helper.createEnrollment(student, courses.get(1).getId()); // 자료구조
+        helper.createEnrollment(student, courses.get(2).getId()); // 운영체제
 
+    }
+
+    /**
+     * 대학 생성 메서드
+     */
+    private List<University> initUniversity() {
+        List<University> universities = new ArrayList<>();
+
+        University uni1 = helper.createUniversity("A대학교", "auni.ac.kr");
+        universities.add(uni1);
+
+        return universities;
+    }
+
+    /**
+     * 전공 생성 메서드
+     */
+    private List<Major> initMajor(University university) {
+        List<Major> majors = new ArrayList<>();
+
+        Major major1 = helper.createMajor("소프트웨어전공", university);
+        majors.add(major1);
+        Major major2 = helper.createMajor("컴퓨터공학전공", university);
+        majors.add(major2);
+
+        return majors;
+    }
+
+    /**
+     * 학생 계정 생성 메서드
+     */
+    private void initStudent(University university, Major major) {
+        // 1학년 학생 생성1
+        helper.createStudent("teststudent@auni.ac.kr", "password", "테스트학생", "20250002",
+                university.getId(), major.getId(), 1, 1);
+
+        // 1학년 학생 생성2
+        helper.createStudent("teststudent2@auni.ac.kr", "password", "테스트학생2", "20250003",
+                university.getId(), major.getId(), 1, 1);
+
+        // 2학년 학생 생성
+        helper.createStudent("teststudent3@auni.ac.kr", "password", "테스트2학년학생1", "25020001",
+                university.getId(), major.getId(), 2, 1);
+
+        // 3학년 학생 생성
+        helper.createStudent("test3rdstudent@auni.ac.kr", "password", "테스트3학년학생1", "25030001",
+                university.getId(), major.getId(), 3, 1);
+
+        // 4학년 학생 생성
+        helper.createStudent("test4thstudent@auni.ac.kr", "password", "테스트4학년학생1", "25040001",
+                university.getId(), major.getId(), 4, 1);
+    }
+
+    /**
+     * 교수 계정 생성 메서드
+     */
+    private List<Member> initProfessor(University university, Major major) {
+
+        List<Member> professors = new ArrayList<>();
+
+        // 승인된 교수 (로그인 성공용)
+        Member approvedProfessor = helper.createProfessor("professor@auni.ac.kr", "password", "김교수", "EMP00001",
+                university.getId(), major.getId(), ApprovalStatus.APPROVED);
+        professors.add(approvedProfessor);
+
+        // 승인 안 된 교수 (로그인 실패용)
+        Member pendingProfessor = helper.createProfessor("pending@auni.ac.kr", "password", "대기중교수", "EMP00002",
+                university.getId(), major.getId(), ApprovalStatus.PENDING);
+        professors.add(pendingProfessor);
+
+        return professors;
+    }
+
+    /**
+     * 관리자 계정 생성 메서드
+     */
+    private void initAdmin() {
+        helper.createAdmin("adminmaster@auni.ac.kr", "adminPw", "관리자", passwordEncoder);
+    }
+
+    /**
+     * 수강신청 기간을 생성하는 메서드
+     */
+    private void initEnrollmentPeriod(University university) {
         // 수강신청 기간 설정 (1학년·1학기)
         int year = LocalDate.now().getYear();
         helper.createEnrollmentPeriod(
@@ -75,55 +168,83 @@ public class InitTestData {
                 LocalDate.of(year, 5, 31)
         );
 
-        // 2-2) 테스트용 강좌 3개 생성
-        List<Course> courses = initTestCourses(major, authenticatedProfessor.getProfessorProfile());
+        // 수강신청 기간 설정 (2학년·1학기) 없음
 
-        // 2-3) 기존 생성되어있던 테스트학생에 2개의 수강신청 정보를 등록함
-        Member student = helper.getMemberByEmail("teststudent@auni.ac.kr");
-        helper.createEnrollment(student, courses.get(0).getId());
-        helper.createEnrollment(student, courses.get(1).getId());
-
-        // 2-3) 예외 검증용 강좌
-        //  정원초과 강좌
-        Course full = helper.createCourse("정원초과강좌", major, "OO동 104호",
-                1, 1, 3, authenticatedProfessor.getProfessorProfile(),
-                1, 1, "/plans/full.pdf"
+        // 수강신청 기간 설정 (3학년·1학기, 아직 기간 안됨)
+        helper.createEnrollmentPeriod(
+                university,
+                year,              // 연도
+                3,                 // 학년
+                1,                 // 학기
+                LocalDate.of(year, 6, 1),
+                LocalDate.of(year, 6, 30)
         );
-        helper.createCourseScheduleAndAssociateWithCourse(full, DayOfWeek.FRI, "09:00:00", "10:00:00");
 
-        //  학점초과 강좌(20학점짜리 강좌, 신청 시 초과)
-        Course heavy = helper.createCourse("학점초과강좌", major, "OO동 105호",
-                30, 0, 20, authenticatedProfessor.getProfessorProfile(),
-                1, 1, "/plans/heavy.pdf"
+        // 수강신청 기간 설정 (4학년·1학기, 기간지남)
+        helper.createEnrollmentPeriod(
+                university,
+                year,              // 연도
+                4,                 // 학년
+                1,                 // 학기
+                LocalDate.of(year, 5, 1),
+                LocalDate.of(year, 5, 9)
         );
-        helper.createCourseScheduleAndAssociateWithCourse(heavy, DayOfWeek.THU, "13:00:00", "15:00:00");
-
-        //  시간표충돌 강좌
-        Course conflict = helper.createCourse("충돌강좌", major, "OO동 106호",
-                30, 0, 3, authenticatedProfessor.getProfessorProfile(),
-                1, 1, "/plans/conflict.pdf"
-        );
-        // 자료구조, 운영체제 수업과 시간표가 겹침
-        helper.createCourseScheduleAndAssociateWithCourse(conflict, DayOfWeek.MON, "10:00:00", "11:00:00");
-        helper.createCourseScheduleAndAssociateWithCourse(conflict, DayOfWeek.TUE, "10:00:00", "11:00:00");
     }
 
     /**
      * Major + ProfessorProfile 기반으로 3개의 테스트용 강좌 생성
      */
     private List<Course> initTestCourses(Major major, ProfessorProfile prof) {
-        Course c1 = helper.createCourse("자료구조", major, "OO동 101호", 30, 0, 3, prof, 1, 1, "/plans/ds.pdf");
-        helper.createCourseScheduleAndAssociateWithCourse(c1, DayOfWeek.MON, "09:00:00", "10:30:00");
-        helper.createCourseScheduleAndAssociateWithCourse(c1, DayOfWeek.WED, "11:00:00", "12:30:00");
 
-        Course c2 = helper.createCourse("운영체제", major, "OO동 102호", 30, 0, 4, prof, 1, 1, "/plans/os.pdf");
-        helper.createCourseScheduleAndAssociateWithCourse(c2, DayOfWeek.TUE, "09:00:00", "10:30:00");
-        helper.createCourseScheduleAndAssociateWithCourse(c2, DayOfWeek.THU, "11:00:00", "12:30:00");
+        List<Course> courses = new ArrayList<>();
 
-        Course c3 = helper.createCourse("네트워크", major, "OO동 103호", 20, 0, 3, prof, 1, 1, "/plans/net.pdf");
-        helper.createCourseScheduleAndAssociateWithCourse(c3, DayOfWeek.TUE, "14:00:00", "15:30:00");
-        helper.createCourseScheduleAndAssociateWithCourse(c3, DayOfWeek.FRI, "16:00:00", "17:30:00");
+        Course c1 = helper.createCourse("컴파일러", major, "공학관A", 200, 0, 4,
+                prof, 4, 1, "/somePath/someAttachment.jpg");
+        courses.add(c1);
 
-        return List.of(c1, c2, c3);
+        Course c2 = helper.createCourse("자료구조", major, "OO동 101호", 30, 0, 3, prof, 1, 1, "/plans/ds.pdf");
+        helper.createCourseScheduleAndAssociateWithCourse(c2, DayOfWeek.MON, "09:00:00", "10:30:00");
+        helper.createCourseScheduleAndAssociateWithCourse(c2, DayOfWeek.WED, "11:00:00", "12:30:00");
+        courses.add(c2);
+
+        Course c3 = helper.createCourse("운영체제", major, "OO동 102호", 30, 0, 4, prof, 1, 1, "/plans/os.pdf");
+        helper.createCourseScheduleAndAssociateWithCourse(c3, DayOfWeek.TUE, "09:00:00", "10:30:00");
+        helper.createCourseScheduleAndAssociateWithCourse(c3, DayOfWeek.THU, "11:00:00", "12:30:00");
+        courses.add(c3);
+
+        Course c4 = helper.createCourse("네트워크", major, "OO동 103호", 20, 0, 3, prof, 1, 1, "/plans/net.pdf");
+        helper.createCourseScheduleAndAssociateWithCourse(c4, DayOfWeek.TUE, "14:00:00", "15:30:00");
+        helper.createCourseScheduleAndAssociateWithCourse(c4, DayOfWeek.FRI, "16:00:00", "17:30:00");
+        courses.add(c4);
+
+        return courses;
+    }
+
+    /**
+     * 정원초과, 학점초과, 시간표충돌 강좌 생성 메서드
+     */
+    private void initConflictCourses(Major major, ProfessorProfile professorProfile) {
+        //  정원초과 강좌
+        Course full = helper.createCourse("정원초과강좌", major, "OO동 104호",
+                1, 1, 3, professorProfile,
+                1, 1, "/plans/full.pdf"
+        );
+        helper.createCourseScheduleAndAssociateWithCourse(full, DayOfWeek.FRI, "09:00:00", "10:00:00");
+
+        //  학점초과 강좌(20학점짜리 강좌, 신청 시 초과)
+        Course heavy = helper.createCourse("학점초과강좌", major, "OO동 105호",
+                30, 0, 20, professorProfile,
+                1, 1, "/plans/heavy.pdf"
+        );
+        helper.createCourseScheduleAndAssociateWithCourse(heavy, DayOfWeek.THU, "13:00:00", "15:00:00");
+
+        //  시간표충돌 강좌
+        Course conflict = helper.createCourse("충돌강좌", major, "OO동 106호",
+                30, 0, 3, professorProfile,
+                1, 1, "/plans/conflict.pdf"
+        );
+        // 자료구조, 운영체제 수업과 시간표가 겹침
+        helper.createCourseScheduleAndAssociateWithCourse(conflict, DayOfWeek.MON, "10:00:00", "11:00:00");
+        helper.createCourseScheduleAndAssociateWithCourse(conflict, DayOfWeek.TUE, "10:00:00", "11:00:00");
     }
 }

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/security/SecurityConfig.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/security/SecurityConfig.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -18,6 +19,7 @@ import static com.WEB4_5_GPT_BE.unihub.global.security.SecurityConstants.AUTH_WH
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
+@EnableMethodSecurity(securedEnabled = true)
 public class SecurityConfig {
 
   private final CustomAuthenticationFilter customAuthenticationFilter;

--- a/backend/src/main/resources/application-stg.yml
+++ b/backend/src/main/resources/application-stg.yml
@@ -19,7 +19,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: false

--- a/backend/src/main/resources/application-stg.yml
+++ b/backend/src/main/resources/application-stg.yml
@@ -19,7 +19,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         format_sql: false

--- a/backend/src/test/java/com/WEB4_5_GPT_BE/unihub/domain/course/service/CourseServiceTest.java
+++ b/backend/src/test/java/com/WEB4_5_GPT_BE/unihub/domain/course/service/CourseServiceTest.java
@@ -411,27 +411,61 @@ class CourseServiceTest {
 
     // 나머지 2가지 검색 타입에 대한 테스트 생략
     @Test
-    @DisplayName("검색어(제목, 교수명)와 페이지네이션 정보로 강의를 목록 조회한다.")
-    void givenSearchKeywordsAndPaginationObject_whenRequestingCourseList_thenReturnCourseList() {
+    @DisplayName("검색어(제목, 교수명, 전공, 학년, 학기)와 페이지네이션 정보로 강의 목록을 조회한다.")
+    void givenSearchConditionsAndPagination_whenRequestingCourseList_thenReturnFilteredCourseList() {
+        // given
         PageRequest pageable = PageRequest.of(0, 5, Sort.by("credit").descending());
         Page<Course> page = new PageImpl<>(
-                List.of(testCourse1, testCourse2, testCourse3),
+                List.of(testCourse1, testCourse2),
                 pageable,
-                12
+                2
         );
+
         SecurityUser authUser = new SecurityUser(testMember1, List.of(new SimpleGrantedAuthority("ROLE_PROFESSOR")));
-        ArgumentCaptor<Long> longCaptor = ArgumentCaptor.forClass(Long.class);
-        given(professorProfileRepository.findByMemberId(testMember1.getId())).willReturn(Optional.of(testProfessorProfile1));
-        given(courseRepository.findByTitleLikeAndProfessorNameLike(longCaptor.capture(), anyString(), anyString(), any(Pageable.class)))
-                .willReturn(page);
 
-        Page<CourseWithFullScheduleResponse> result = courseService.findAllCoursesModeFull("", "", authUser, pageable);
-        Long captured = longCaptor.getValue();
+        Long majorId = 1L;
+        Integer grade = 2;
+        Integer semester = 1;
 
-        assertThat(result).isInstanceOf(Page.class);
-        assertThat(result.getNumberOfElements()).isEqualTo(3);
-        assertThat(captured).isEqualTo(testProfessorProfile1.getUniversity().getId());
+        ArgumentCaptor<Long> universityIdCaptor = ArgumentCaptor.forClass(Long.class);
+        ArgumentCaptor<String> titleCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> profNameCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Long> majorIdCaptor = ArgumentCaptor.forClass(Long.class);
+        ArgumentCaptor<Integer> gradeCaptor = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<Integer> semesterCaptor = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+
+        given(professorProfileRepository.findByMemberId(testMember1.getId()))
+                .willReturn(Optional.of(testProfessorProfile1));
+        given(courseRepository.findWithFilters(
+                universityIdCaptor.capture(),
+                titleCaptor.capture(),
+                profNameCaptor.capture(),
+                majorIdCaptor.capture(),
+                gradeCaptor.capture(),
+                semesterCaptor.capture(),
+                pageableCaptor.capture()
+        )).willReturn(page);
+
+        // when
+        Page<CourseWithFullScheduleResponse> result = courseService.findAllCoursesModeFull(
+                "검색제목", "교수이름", majorId, grade, semester, authUser, pageable
+        );
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getNumberOfElements()).isEqualTo(2);
+        assertThat(universityIdCaptor.getValue()).isEqualTo(testProfessorProfile1.getUniversity().getId());
+        assertThat(titleCaptor.getValue()).isEqualTo("검색제목");
+        assertThat(profNameCaptor.getValue()).isEqualTo("교수이름");
+        assertThat(majorIdCaptor.getValue()).isEqualTo(majorId);
+        assertThat(gradeCaptor.getValue()).isEqualTo(grade);
+        assertThat(semesterCaptor.getValue()).isEqualTo(semester);
+        assertThat(pageableCaptor.getValue()).isEqualTo(pageable);
+
         then(professorProfileRepository).should().findByMemberId(testMember1.getId());
-        then(courseRepository).should().findByTitleLikeAndProfessorNameLike(anyLong(), anyString(), anyString(), any(Pageable.class));
+        then(courseRepository).should().findWithFilters(
+                anyLong(), anyString(), anyString(), any(), any(), any(), any(Pageable.class)
+        );
     }
 }

--- a/backend/src/test/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/controller/EnrollmentEventControllerTest.java
+++ b/backend/src/test/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/controller/EnrollmentEventControllerTest.java
@@ -74,7 +74,7 @@ public class EnrollmentEventControllerTest {
         QueueStatusDto initialStatus = new QueueStatusDto(true, 0, 0);
         when(enrollmentQueueService.getQueueStatus("1")).thenReturn(initialStatus);
 
-        mockMvc.perform(get("/api/enrollment/events")
+        mockMvc.perform(get("/api/enrollments/events")
                         .accept(MediaType.TEXT_EVENT_STREAM_VALUE))
                 .andExpect(status().isOk())
                 .andExpect(request().asyncStarted());
@@ -86,7 +86,7 @@ public class EnrollmentEventControllerTest {
     @Test
     @DisplayName("대기열 추가 요청 테스트")
     public void testJoinQueue() throws Exception {
-        mockMvc.perform(post("/api/enrollment/queue/join")
+        mockMvc.perform(post("/api/enrollments/queue/join")
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -103,7 +103,7 @@ public class EnrollmentEventControllerTest {
     @Test
     @DisplayName("대기열 상태 조회 요청 테스트")
     public void testGetQueueStatus() throws Exception {
-        mockMvc.perform(get("/api/enrollment/queue/status")
+        mockMvc.perform(get("/api/enrollments/queue/status")
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value("200"))
@@ -119,7 +119,7 @@ public class EnrollmentEventControllerTest {
     @Test
     @DisplayName("세션 해제 요청 테스트")
     public void testReleaseSession() throws Exception {
-        mockMvc.perform(post("/api/enrollment/queue/release")
+        mockMvc.perform(post("/api/enrollments/queue/release")
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value("200"))

--- a/backend/src/test/java/com/WEB4_5_GPT_BE/unihub/domain/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/WEB4_5_GPT_BE/unihub/domain/member/controller/MemberControllerTest.java
@@ -5,11 +5,15 @@ import com.WEB4_5_GPT_BE.unihub.domain.member.dto.request.MemberLoginRequest;
 import com.WEB4_5_GPT_BE.unihub.domain.member.dto.request.PasswordResetConfirmationRequest;
 import com.WEB4_5_GPT_BE.unihub.domain.member.dto.request.ProfessorSignUpRequest;
 import com.WEB4_5_GPT_BE.unihub.domain.member.dto.request.StudentSignUpRequest;
-import com.WEB4_5_GPT_BE.unihub.domain.member.dto.request.mypage.*;
+import com.WEB4_5_GPT_BE.unihub.domain.member.dto.request.mypage.UpdateEmailRequest;
+import com.WEB4_5_GPT_BE.unihub.domain.member.dto.request.mypage.UpdateMajorRequest;
+import com.WEB4_5_GPT_BE.unihub.domain.member.dto.request.mypage.UpdatePasswordRequest;
+import com.WEB4_5_GPT_BE.unihub.domain.member.dto.request.mypage.VerifyPasswordRequest;
 import com.WEB4_5_GPT_BE.unihub.domain.member.service.EmailService;
 import com.WEB4_5_GPT_BE.unihub.global.config.RedisTestContainerConfig;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.Cookie;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,16 +22,19 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
 @Transactional
@@ -95,7 +102,7 @@ public class MemberControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("로그인에 성공했습니다."))
                 .andExpect(jsonPath("$.data.accessToken").exists())
-                .andExpect(jsonPath("$.data.refreshToken").exists());
+                .andExpect(header().string("Set-Cookie", Matchers.containsString("refreshToken=")));;
     }
 
     @Test
@@ -120,14 +127,23 @@ public class MemberControllerTest {
     void refreshToken_success() throws Exception {
         MemberLoginRequest loginRequest = new MemberLoginRequest("teststudent@auni.ac.kr", "password");
 
-        String loginResponse = mockMvc.perform(post("/api/members/login")
+        MockHttpServletResponse loginResponse = mockMvc.perform(post("/api/members/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(loginRequest)))
-                .andReturn().getResponse().getContentAsString();
+                .andReturn()
+                .getResponse();
 
-        String refreshToken = objectMapper.readTree(loginResponse).path("data").path("refreshToken").asText();
+        Cookie refreshTokenCookie = Arrays.stream(loginResponse.getCookies())
+                .filter(cookie -> "refreshToken".equals(cookie.getName()))
+                .findFirst()
+                .orElse(null);
 
-        mockMvc.perform(post("/api/members/refresh").cookie(new Cookie("refreshToken", refreshToken)))
+        assertThat(refreshTokenCookie)
+                .as("refreshToken 쿠키가 응답에 포함되어야 합니다.")
+                .isNotNull();
+
+        mockMvc.perform(post("/api/members/refresh")
+                        .cookie(refreshTokenCookie))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("새로운 토큰이 발급되었습니다."))
                 .andExpect(jsonPath("$.data.accessToken").exists());


### PR DESCRIPTION
## ✨ 변경 사항 설명

- docs: 개발용 초기 데이터 최신화 (ddl-auto=create) 후 재배포, 테스트 서버용 초기 데이터 적용 후 ddl-auto=update로 복원
- fix: API 명세서와 다른 부분 및 기타 버그 수정 (#90)
- feat: 관리자 전용 API에 `@PreAuthorize` 적용 (#95)
- feat: StudentProfileResponse / ProfessorProfileResponse에 `universityId` 필드 추가 (#100)
- feat: 로그인 시 `refreshToken` 응답 제거 및 저장 기간 1일로 변경 (#104)
- feat: 학년·학기·전공 필터링 기능 추가 (#107)
- feat: 내 수강신청 기간 조회 API 개발 및 InitData 코드 가독성 개선 (#111)

## ✅ 체크리스트

<!-- 📝 완료된 항목은 [x]로 표시해주세요. -->

- [ ] 🏗️ 코드가 **코딩 스타일 가이드**를 준수합니다.
- [ ] 🧪 변경 사항에 대한 **테스트가 추가**되었습니다.
- [ ] ✅ 모든 **테스트가 정상적으로 통과**합니다.
- [ ] 📚 필요한 **문서가 업데이트**되었습니다.

## 🎨 스크린샷 (UI 변경이 있는 경우)

<!-- 🖼️ 변경 전/후 스크린샷을 추가해주세요. -->

## 🛠️ 테스트 방법 (필요시)

<!-- 🧑‍💻 이 PR을 테스트하는 방법을 설명해주세요. -->
