### PR TITLE
json과 file을 함께 request로 받게될 경우 Content-Type을 직접 application/json으로 명시해줘야 하는 문제 해결

### DIFF
--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/course/controller/CourseController.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/course/controller/CourseController.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
@@ -32,6 +33,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequestMapping("/api/courses")
 @RequiredArgsConstructor
+@SecurityRequirement(name = "accessToken을 사용한 bearerAuth 로그인 인증")
 public class CourseController {
 
     private final CourseService courseService;

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/util/MultipartJackson2HttpMessageConverter.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/util/MultipartJackson2HttpMessageConverter.java
@@ -1,0 +1,52 @@
+package com.WEB4_5_GPT_BE.unihub.global.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Type;
+
+/**
+ * HTTP multipart/form-data 요청에서 JSON 파트를 application/octet-stream으로 전송하더라도
+ * Jackson 메시지 컨버터를 통해 객체로 바인딩할 수 있도록 지원하는 HTTP 메시지 컨버터입니다.
+ * <p>
+ * Spring 기본 컨버터는 multipart 파일 업로드 시 JSON 파트가 application/octet-stream으로 처리되면
+ * 자동으로 JSON으로 파싱하지 않으므로, 이 컨버터를 추가하여 해당 문제를 해결합니다.
+ */
+@Component
+public class MultipartJackson2HttpMessageConverter extends AbstractJackson2HttpMessageConverter {
+
+    /**
+     * ObjectMapper를 주입받아 application/octet-stream 미디어 타입을 처리 대상으로 설정합니다.
+     *
+     * @param objectMapper JSON 파싱을 위한 ObjectMapper
+     */
+    public MultipartJackson2HttpMessageConverter(ObjectMapper objectMapper) {
+        super(objectMapper, MediaType.APPLICATION_OCTET_STREAM);
+    }
+
+    /**
+     * 쓰기 기능은 지원하지 않으므로 항상 false를 반환합니다.
+     */
+    @Override
+    public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    /**
+     * 쓰기 기능은 지원하지 않으므로 항상 false를 반환합니다.
+     */
+    @Override
+    public boolean canWrite(Type type, Class<?> contextClass, MediaType mediaType) {
+        return false;
+    }
+
+    /**
+     * 응답 바디 직렬화를 위한 쓰기 지원도 비활성화합니다.
+     */
+    @Override
+    protected boolean canWrite(MediaType mediaType) {
+        return false;
+    }
+}


### PR DESCRIPTION
## ✨ 변경 사항 설명

![image](https://github.com/user-attachments/assets/2083d6b4-28ba-4269-90c2-d44ca869e4b9)
json과 file을 파라메터로 함께 받아오기위해서
multipart/form-data을 사용했습니다.

![image](https://github.com/user-attachments/assets/f2e33840-4145-4412-821c-ef4139f0170f)
이때 multipart/form-data의 경우
Content-type 설정이 application/json이 아니라 application/octet-stream 으로 설정되는데
octet-stream은 json으로 자동 파싱이 안됩니다. 그래서

1. 직접 content-type을 application/json 으로 명시 안해주면 값을 읽지 못하여 오류 발생
2. 코드 상에서 자동으로 명시해주도록 추가하려했으나 추가하는 방법이 없음

해결
MultipartJackson2HttpMessageConverter 라는 컨버터를 만들어서
multipart로 들어온 JSON 파트가 application/octet-stream으로 입력되는 경우에도 application/json으로 파싱할 수 있도록 해결함

## ✅ 체크리스트

<!-- 📝 완료된 항목은 [x]로 표시해주세요. -->

- [ ] 🏗️ 코드가 **코딩 스타일 가이드**를 준수합니다.
- [ ] 🧪 변경 사항에 대한 **테스트가 추가**되었습니다.
- [ ] ✅ 모든 **테스트가 정상적으로 통과**합니다.
- [ ] 📚 필요한 **문서가 업데이트**되었습니다.

## 🎨 스크린샷 (UI 변경이 있는 경우)

<!-- 🖼️ 변경 전/후 스크린샷을 추가해주세요. -->

## 🛠️ 테스트 방법 (필요시)

<!-- 🧑‍💻 이 PR을 테스트하는 방법을 설명해주세요. -->
