### PR TITLE
feat: 강의 등록, 수정 시 json 형태의 입력값에서는 강의계획서 url 을 받지 않도록 제거함

### DIFF
--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/course/controller/CourseController.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/course/controller/CourseController.java
@@ -1,8 +1,8 @@
 package com.WEB4_5_GPT_BE.unihub.domain.course.controller;
 
 import com.WEB4_5_GPT_BE.unihub.domain.common.enums.CourseListReturnMode;
-import com.WEB4_5_GPT_BE.unihub.domain.course.dto.CourseRequest;
 import com.WEB4_5_GPT_BE.unihub.domain.course.dto.CourseWithFullScheduleResponse;
+import com.WEB4_5_GPT_BE.unihub.domain.course.dto.CourseWithOutUrlRequest;
 import com.WEB4_5_GPT_BE.unihub.domain.course.service.CourseService;
 import com.WEB4_5_GPT_BE.unihub.global.response.Empty;
 import com.WEB4_5_GPT_BE.unihub.global.response.RsData;
@@ -62,7 +62,7 @@ public class CourseController {
      * 발급된 URL을 `coursePlanAttachment` 필드에 저장합니다.
      * - 강의실/교수 스케줄 충돌 여부 및 전공·교수 유효성을 검증한 뒤 저장합니다.
      *
-     * @param courseRequest  생성할 강의의 상세 데이터 (JSON, `data` 파트)
+     * @param courseWithOutUrlRequest  생성할 강의의 상세 데이터 (JSON, `data` 파트)
      * @param coursePlanFile 강의계획서 파일 (multipart `file` 파트)
      * @return 생성된 강의 정보를 담은 {@link CourseWithFullScheduleResponse}
      */
@@ -78,12 +78,12 @@ public class CourseController {
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public RsData<CourseWithFullScheduleResponse> createCourse(
             @Parameter(description = "생성할 강의 정보를 담은 JSON", content = @Content(mediaType = "application/json"))
-            @RequestPart("data") CourseRequest courseRequest,
+            @RequestPart("data") CourseWithOutUrlRequest courseWithOutUrlRequest,
 
             @Parameter(description = "강의계획서 파일", content = @Content(mediaType = "application/octet-stream"))
             @RequestPart(name = "file", required = false) MultipartFile coursePlanFile
     ) {
-        CourseWithFullScheduleResponse res = courseService.createCourse(courseRequest, coursePlanFile);
+        CourseWithFullScheduleResponse res = courseService.createCourse(courseWithOutUrlRequest, coursePlanFile);
         return new RsData<>(String.valueOf(HttpStatus.CREATED.value()), "성공적으로 생성되었습니다.", res);
     }
 
@@ -94,7 +94,7 @@ public class CourseController {
      * - 스케줄, 전공/교수 등 유효성 검사 후 충돌이 없으면 덮어씌우기 방식으로 업데이트합니다.
      *
      * @param courseId       수정 대상 강의의 ID
-     * @param courseRequest  수정할 강의의 상세 데이터 (JSON, `data` 파트)
+     * @param courseWithOutUrlRequest  수정할 강의의 상세 데이터 (JSON, `data` 파트)
      * @param coursePlanFile 새로운 강의계획서 파일 (multipart `file` 파트)
      * @return 수정된 강의 정보를 담은 {@link CourseWithFullScheduleResponse}
      */
@@ -115,12 +115,12 @@ public class CourseController {
             @PathVariable Long courseId,
 
             @Parameter(description = "수정할 강의 정보를 담은 JSON", content = @Content(mediaType = "application/json"))
-            @RequestPart("data") CourseRequest courseRequest,
+            @RequestPart("data") CourseWithOutUrlRequest courseWithOutUrlRequest,
 
             @Parameter(description = "새로운 강의계획서 파일", content = @Content(mediaType = "application/octet-stream"))
             @RequestPart(name = "file", required = false) MultipartFile coursePlanFile
     ) {
-        CourseWithFullScheduleResponse res = courseService.updateCourse(courseId, courseRequest, coursePlanFile);
+        CourseWithFullScheduleResponse res = courseService.updateCourse(courseId, courseWithOutUrlRequest, coursePlanFile);
         return new RsData<>(String.valueOf(HttpStatus.OK.value()), "성공적으로 수정되었습니다.", res);
     }
 

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/course/dto/CourseRequest.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/course/dto/CourseRequest.java
@@ -67,23 +67,4 @@ public record CourseRequest(
                 course.getSchedules().stream().map(CourseScheduleDto::from).toList()
         );
     }
-
-    /**
-     * 새로운 coursePlanAttachment 로 교체한 새 CourseRequest 를 만듭니다.
-     */
-    public CourseRequest withCoursePlanAttachment(String newAttachment) {
-        return new CourseRequest(
-                this.title,
-                this.major,
-                this.university,
-                this.location,
-                this.capacity,
-                this.credit,
-                this.employeeId,
-                this.grade,
-                this.semester,
-                newAttachment,
-                this.schedule
-        );
-    }
 }

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/course/dto/CourseWithOutUrlRequest.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/course/dto/CourseWithOutUrlRequest.java
@@ -1,0 +1,50 @@
+package com.WEB4_5_GPT_BE.unihub.domain.course.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+@Schema(description = "하나의 강의를 나타내는 DTO.")
+public record CourseWithOutUrlRequest(
+        @Schema(description = "강의 제목")
+        @NotEmpty String title,
+        @Schema(description = "강의 전공")
+        @NotEmpty String major,
+        @Schema(description = "소속 대학")
+        @NotEmpty String university,
+        @Schema(description = "강의장")
+        @NotEmpty String location,
+        @Schema(description = "수강 정원")
+        @NotEmpty Integer capacity,
+        @Schema(description = "단위 학점")
+        @NotEmpty Integer credit,
+        @Schema(description = "강사/교수 사번")
+        String employeeId,
+        @Schema(description = "대상 학년")
+        @NotEmpty Integer grade,
+        @Schema(description = "제공 학기")
+        @NotEmpty Integer semester,
+        @Schema(description = "강의 스케줄")
+        List<CourseScheduleDto> schedule
+) {
+
+    /**
+     * 새로운 coursePlanAttachment를 추가한 새 CourseRequest 를 만듭니다.
+     */
+    public CourseRequest withCoursePlanAttachment(String newAttachment) {
+        return new CourseRequest(
+                this.title,
+                this.major,
+                this.university,
+                this.location,
+                this.capacity,
+                this.credit,
+                this.employeeId,
+                this.grade,
+                this.semester,
+                newAttachment,
+                this.schedule
+        );
+    }
+}

--- a/backend/src/test/java/com/WEB4_5_GPT_BE/unihub/domain/course/controller/CourseControllerTest.java
+++ b/backend/src/test/java/com/WEB4_5_GPT_BE/unihub/domain/course/controller/CourseControllerTest.java
@@ -3,15 +3,16 @@ package com.WEB4_5_GPT_BE.unihub.domain.course.controller;
 import com.WEB4_5_GPT_BE.unihub.domain.common.enums.DayOfWeek;
 import com.WEB4_5_GPT_BE.unihub.domain.course.dto.CourseRequest;
 import com.WEB4_5_GPT_BE.unihub.domain.course.dto.CourseWithFullScheduleResponse;
+import com.WEB4_5_GPT_BE.unihub.domain.course.dto.CourseWithOutUrlRequest;
 import com.WEB4_5_GPT_BE.unihub.domain.course.entity.Course;
 import com.WEB4_5_GPT_BE.unihub.domain.course.entity.CourseSchedule;
 import com.WEB4_5_GPT_BE.unihub.domain.course.service.CourseService;
-import com.WEB4_5_GPT_BE.unihub.global.infra.s3.S3Service;
 import com.WEB4_5_GPT_BE.unihub.domain.member.service.AuthTokenService;
 import com.WEB4_5_GPT_BE.unihub.domain.university.entity.Major;
 import com.WEB4_5_GPT_BE.unihub.domain.university.entity.University;
 import com.WEB4_5_GPT_BE.unihub.global.Rq;
 import com.WEB4_5_GPT_BE.unihub.global.alert.AlertNotifier;
+import com.WEB4_5_GPT_BE.unihub.global.infra.s3.S3Service;
 import com.WEB4_5_GPT_BE.unihub.global.security.CustomAuthenticationFilter;
 import com.WEB4_5_GPT_BE.unihub.global.security.SecurityUser;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -154,7 +155,7 @@ class CourseControllerTest {
 //                    .content(objectMapper.writeValueAsString(CourseRequest.from(testCourse))));
 
         // 1) service stub: CourseRequest + no file
-        given(courseService.createCourse(any(CourseRequest.class), isNull()))
+        given(courseService.createCourse(any(CourseWithOutUrlRequest.class), isNull()))
                 .willReturn(CourseWithFullScheduleResponse.from(testCourse));
 
         // 2) JSON part 준비 (@RequestPart("data"))
@@ -182,7 +183,7 @@ class CourseControllerTest {
                 .andExpect(jsonPath("$.data.schedule", hasSize(2)))
                 .andExpect(jsonPath("$.data.schedule[0].day").value(testCourse.getSchedules().getFirst().getDay().toString()));
         then(courseService).should()
-                .createCourse(any(CourseRequest.class), isNull());
+                .createCourse(any(CourseWithOutUrlRequest.class), isNull());
     }
 
     @Test
@@ -206,7 +207,7 @@ class CourseControllerTest {
         courseWithAttachment.getSchedules().addAll(testCourse.getSchedules());
 
         // — 2) 서비스 스텁: 2-arg 버전에 스텁을 걸어줌
-        given(courseService.createCourse(any(CourseRequest.class), any(MultipartFile.class)))
+        given(courseService.createCourse(any(CourseWithOutUrlRequest.class), any(MultipartFile.class)))
                 .willReturn(CourseWithFullScheduleResponse.from(courseWithAttachment));
 
         // — 3) JSON data 파트
@@ -246,7 +247,7 @@ class CourseControllerTest {
 
         given(courseService.updateCourse(
                 eq(courseId),
-                any(CourseRequest.class),
+                any(CourseWithOutUrlRequest.class),
                 isNull()
         )).willReturn(CourseWithFullScheduleResponse.from(testCourse));
 
@@ -275,7 +276,7 @@ class CourseControllerTest {
 
         // verify + captor
         ArgumentCaptor<Long> idCaptor = ArgumentCaptor.forClass(Long.class);
-        ArgumentCaptor<CourseRequest> reqCaptor = ArgumentCaptor.forClass(CourseRequest.class);
+        ArgumentCaptor<CourseWithOutUrlRequest> reqCaptor = ArgumentCaptor.forClass(CourseWithOutUrlRequest.class);
         verify(courseService).updateCourse(
                 idCaptor.capture(),
                 reqCaptor.capture(),
@@ -309,7 +310,7 @@ class CourseControllerTest {
         // 2) service stub
         given(courseService.updateCourse(
                 eq(courseId),
-                any(CourseRequest.class),
+                any(CourseWithOutUrlRequest.class),
                 any(MultipartFile.class))
         ).willReturn(CourseWithFullScheduleResponse.from(courseWithNewAttachment));
 
@@ -336,7 +337,7 @@ class CourseControllerTest {
                 .andExpect(jsonPath("$.data.coursePlanAttachment").value(newUrl));
 
         then(courseService).should()
-                .updateCourse(eq(courseId), any(CourseRequest.class), any(MultipartFile.class));
+                .updateCourse(eq(courseId), any(CourseWithOutUrlRequest.class), any(MultipartFile.class));
     }
 
     @Test


### PR DESCRIPTION


## ✨ 변경 사항 설명

- 등록된 파일을 기준으로 백에서 업로드 후 url을 발급받기 때문에 front로 부터 url을 받아올 이유가 없음
- 혼동 방지하고자 입력 필드 제거 (url 입력값을 받지않는 별도의 dto를 생성함)

## ✅ 체크리스트

<!-- 📝 완료된 항목은 [x]로 표시해주세요. -->

- [ ] 🏗️ 코드가 **코딩 스타일 가이드**를 준수합니다.
- [ ] 🧪 변경 사항에 대한 **테스트가 추가**되었습니다.
- [ ] ✅ 모든 **테스트가 정상적으로 통과**합니다.
- [ ] 📚 필요한 **문서가 업데이트**되었습니다.

## 🎨 스크린샷 (UI 변경이 있는 경우)

<!-- 🖼️ 변경 전/후 스크린샷을 추가해주세요. -->

## 🛠️ 테스트 방법 (필요시)

<!-- 🧑‍💻 이 PR을 테스트하는 방법을 설명해주세요. -->
