### PR TITLE
[REFACTOR] 강의 도메인 버그픽스 및 리팩토링

### DIFF
--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/course/controller/CourseController.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/course/controller/CourseController.java
@@ -184,10 +184,6 @@ public class CourseController {
             @AuthenticationPrincipal SecurityUser principal,
             @Parameter(hidden = true)
             @PageableDefault @ParameterObject Pageable pageable) {
-        // TODO: 인증이 안되어있는 상태에서 요청이 들어오면 인증 정보에서 소속 대학ID를 꺼내오는 과정에서 NPE가 발생한다.
-//        if (principal == null) {
-//            return new RsData<>(String.valueOf(HttpStatus.UNAUTHORIZED.value()), "인증이 필요합니다.");
-//        }
         return switch (mode) {
             case FULL -> new RsData<>(String.valueOf(HttpStatus.OK.value()),
                     "조회에 성공했습니다.",

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/course/entity/CourseSchedule.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/course/entity/CourseSchedule.java
@@ -22,7 +22,6 @@ public class CourseSchedule extends BaseTimeEntity {
   @JoinColumn(name = "course_id", nullable = false)
   private Course course;
 
-  // 조회 성능을 위한 반정규화
   @Column(nullable = false)
   private Long universityId;
 
@@ -40,4 +39,13 @@ public class CourseSchedule extends BaseTimeEntity {
 
   @Column(name = "end_time", nullable = false)
   private LocalTime endTime;
+
+  public static class CourseScheduleBuilder {
+      public CourseSchedule build() {
+          if (startTime.isAfter(endTime)) {
+              throw new IllegalArgumentException("수업 시작 시각이 종료 시각보다 늦습니다.");
+          }
+          return new CourseSchedule(id, course, universityId, location, professorProfileEmployeeId, day, startTime, endTime);
+      }
+  }
 }

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/course/exception/LocationScheduleConflictException.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/course/exception/LocationScheduleConflictException.java
@@ -1,0 +1,9 @@
+package com.WEB4_5_GPT_BE.unihub.domain.course.exception;
+
+import com.WEB4_5_GPT_BE.unihub.global.exception.UnihubException;
+
+public class LocationScheduleConflictException extends UnihubException {
+    public LocationScheduleConflictException() {
+        super("409", "강의 장소가 이미 사용 중입니다.");
+    }
+}

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/course/exception/ProfessorScheduleConflictException.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/course/exception/ProfessorScheduleConflictException.java
@@ -1,0 +1,9 @@
+package com.WEB4_5_GPT_BE.unihub.domain.course.exception;
+
+import com.WEB4_5_GPT_BE.unihub.global.exception.UnihubException;
+
+public class ProfessorScheduleConflictException extends UnihubException {
+    public ProfessorScheduleConflictException() {
+        super("409", "강사/교수가 이미 수업 중입니다.");
+    }
+}

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/course/repository/CourseScheduleRepository.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/course/repository/CourseScheduleRepository.java
@@ -1,79 +1,57 @@
 package com.WEB4_5_GPT_BE.unihub.domain.course.repository;
 
-import com.WEB4_5_GPT_BE.unihub.domain.common.enums.DayOfWeek;
 import com.WEB4_5_GPT_BE.unihub.domain.course.entity.CourseSchedule;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.time.LocalTime;
+import java.util.List;
 
 public interface CourseScheduleRepository extends JpaRepository<CourseSchedule, Long> {
 
-    // TODO: 각 일에 대해 쿼리를 하나씩 보내기보다 강의에 해당하는 CourseSchedule을 목록으로 받아와 서비스에서 검증하도록 수정을 검토 할 것.
     @Query("""
-                SELECT COUNT(*) > 0
+                SELECT cs
                 FROM CourseSchedule cs
-                WHERE cs.professorProfileEmployeeId = :profId
-                    AND cs.day = :dayOfWeek
-                    AND ((:pStartTime <= cs.startTime AND cs.startTime < :pEndTime)
-                    OR (:pStartTime < cs.endTime AND cs.endTime <= :pEndTime))
+                WHERE cs.universityId = :universityId
+                    AND cs.professorProfileEmployeeId = :professorEmpId
             """)
-    Boolean existsByProfEmpIdAndDayOfWeek(
-            @Param("profId") String profId,
-            @Param("dayOfWeek") DayOfWeek dayOfWeek,
-            @Param("pStartTime") LocalTime pStartTime,
-            @Param("pEndTime") LocalTime pEndTime);
+    List<CourseSchedule> findByUniversityIdAndProfessorEmployeeId(
+            @Param("universityId") Long universityId,
+            @Param("professorEmpId") String professorEmpId
+            );
 
     @Query("""
-                SELECT COUNT(*) > 0
+                SELECT cs
                 FROM CourseSchedule cs
-                WHERE cs.professorProfileEmployeeId = :profId
+                WHERE cs.universityId = :universityId
+                    AND cs.professorProfileEmployeeId = :professorEmpId
                     AND cs.course.id != :courseId
-                    AND cs.day = :dayOfWeek
-                    AND ((:pStartTime <= cs.startTime AND cs.startTime < :pEndTime)
-                    OR (:pStartTime < cs.endTime AND cs.endTime <= :pEndTime))
             """)
-    Boolean existsByProfEmpIdAndDayOfWeekExcludingCourse(
-            @Param("profId") String profId,
-            @Param("dayOfWeek") DayOfWeek dayOfWeek,
-            @Param("pStartTime") LocalTime pStartTime,
-            @Param("pEndTime") LocalTime pEndTime,
+    List<CourseSchedule> findByUniversityIdAndProfessorEmployeeIdExcludingCourse(
+            @Param("universityId") Long universityId,
+            @Param("professorEmpId") String professorEmpId,
             @Param("courseId") Long courseId
     );
 
-    // TODO: 위와 같음.
     @Query("""
-                SELECT COUNT(*) > 0
+                SELECT cs
                 FROM CourseSchedule cs
-                WHERE cs.universityId = :univId
+                WHERE cs.universityId = :universityId
                     AND cs.location = :location
-                    AND cs.day = :dayOfWeek
-                    AND ((:pStartTime <= cs.startTime AND cs.startTime < :pEndTime)
-                    OR (:pStartTime < cs.endTime AND cs.endTime <= :pEndTime))
             """)
-    Boolean existsByUnivIdAndLocationAndDayOfWeek(
-            @Param("univId") Long univId,
-            @Param("location") String location,
-            @Param("dayOfWeek") DayOfWeek dayOfWeek,
-            @Param("pStartTime") LocalTime pStartTime,
-            @Param("pEndTime") LocalTime pEndTime);
+    List<CourseSchedule> findByUniversityIdAndLocation(
+            @Param("universityId") Long universityId,
+            @Param("location") String location);
 
     @Query("""
-                SELECT COUNT(*) > 0
+                SELECT cs
                 FROM CourseSchedule cs
-                WHERE cs.universityId = :univId
+                WHERE cs.universityId = :universityId
                     AND cs.location = :location
                     AND cs.course.id != :courseId
-                    AND cs.day = :dayOfWeek
-                    AND ((:pStartTime <= cs.startTime AND cs.startTime < :pEndTime)
-                    OR (:pStartTime < cs.endTime AND cs.endTime <= :pEndTime))
             """)
-    Boolean existsByUnivIdAndLocationAndDayOfWeekExcludingCourse(
-            @Param("univId") Long univId,
+    List<CourseSchedule> findByUniversityIdAndLocationExcludingCourse(
+            @Param("universityId") Long universityId,
             @Param("location") String location,
-            @Param("dayOfWeek") DayOfWeek dayOfWeek,
-            @Param("pStartTime") LocalTime pStartTime,
-            @Param("pEndTime") LocalTime pEndTime,
             @Param("courseId") Long courseId);
 }

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/university/exception/MajorNotFoundException.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/university/exception/MajorNotFoundException.java
@@ -1,0 +1,9 @@
+package com.WEB4_5_GPT_BE.unihub.domain.university.exception;
+
+import com.WEB4_5_GPT_BE.unihub.global.exception.UnihubException;
+
+public class MajorNotFoundException extends UnihubException {
+    public MajorNotFoundException() {
+        super("404", "존재하지 않는 대학교입니다.");
+    }
+}

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/university/exception/UniversityNotFoundException.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/university/exception/UniversityNotFoundException.java
@@ -1,0 +1,9 @@
+package com.WEB4_5_GPT_BE.unihub.domain.university.exception;
+
+import com.WEB4_5_GPT_BE.unihub.global.exception.UnihubException;
+
+public class UniversityNotFoundException extends UnihubException {
+    public UniversityNotFoundException() {
+        super("404", "존재하지 않는 대학교입니다.");
+    }
+}

--- a/backend/src/test/java/com/WEB4_5_GPT_BE/unihub/domain/course/controller/CourseControllerTest.java
+++ b/backend/src/test/java/com/WEB4_5_GPT_BE/unihub/domain/course/controller/CourseControllerTest.java
@@ -46,6 +46,7 @@ import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+@DisplayName("강의 도메인 컨트롤러 레이어 테스트")
 @Import({CourseService.class,
         Rq.class,
         CustomAuthenticationFilter.class,
@@ -361,7 +362,6 @@ class CourseControllerTest {
     @Test
     @DisplayName("강의 목록 조회 요청시 성공.")
     void givenQueryParams_whenRequestingCourseList_thenReturnCourseList() throws Exception {
-        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
 
         //SecurityUser 목 생성
         SecurityUser mockUser = mock(SecurityUser.class);
@@ -379,7 +379,7 @@ class CourseControllerTest {
                 any(),          // grade
                 any(),          // semester
                 any(SecurityUser.class), // principal
-                pageableCaptor.capture()
+                any(Pageable.class)
         )).willReturn(new PageImpl<>(List.of()));
 
         //요청 수행
@@ -387,7 +387,6 @@ class CourseControllerTest {
                 get("/api/courses?mode=FULL&title=프로그래밍&profName=김교수&majorId=1&grade=2&semester=1&sort=credit,desc")
         );
 
-        Pageable captured = pageableCaptor.getValue();
 
         //응답 검증
         resultActions

--- a/backend/src/test/java/com/WEB4_5_GPT_BE/unihub/domain/course/entity/CourseScheduleTest.java
+++ b/backend/src/test/java/com/WEB4_5_GPT_BE/unihub/domain/course/entity/CourseScheduleTest.java
@@ -1,0 +1,57 @@
+package com.WEB4_5_GPT_BE.unihub.domain.course.entity;
+
+import com.WEB4_5_GPT_BE.unihub.domain.common.enums.DayOfWeek;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.catchThrowable;
+
+@DisplayName("강의 스케줄 엔티티 테스트")
+class CourseScheduleTest {
+
+    @Test
+    @DisplayName("빌더에 올바른 값을 넘겨주면 오브젝트가 정상적으로 생성된다.")
+    void givenValidDate_whenInstantiatingCourseScheduleWithBuilder_thenSucceeds() {
+        CourseSchedule courseSchedule = CourseSchedule.builder()
+                .id(123L)
+                .course(new Course())
+                .universityId(321L)
+                .location("testLocation")
+                .professorProfileEmployeeId("testEmpId")
+                .day(DayOfWeek.SAT)
+                .startTime(LocalTime.parse("12:34"))
+                .endTime(LocalTime.parse("23:45"))
+                .build();
+
+        assertThat(courseSchedule.getId()).isEqualTo(123L);
+        assertThat(courseSchedule.getCourse()).isInstanceOf(Course.class);
+        assertThat(courseSchedule.getUniversityId()).isEqualTo(321L);
+        assertThat(courseSchedule.getLocation()).isEqualTo("testLocation");
+        assertThat(courseSchedule.getProfessorProfileEmployeeId()).isEqualTo("testEmpId");
+        assertThat(courseSchedule.getDay()).isEqualTo(DayOfWeek.SAT);
+        assertThat(courseSchedule.getStartTime()).isEqualTo(LocalTime.parse("12:34"));
+        assertThat(courseSchedule.getEndTime()).isEqualTo(LocalTime.parse("23:45"));
+    }
+
+    @Test
+    @DisplayName("빌더에 수업 종료 시각보다 늦은 시작 시각을 넘겨주면 예외를 던진다.")
+    void givenImpossibleTimeframe_whenInstantiatingCourseScheduleWithBuilder_thenThrowsException() {
+        Throwable thrown = catchThrowable(
+                () -> CourseSchedule.builder()
+                        .course(new Course())
+                        .universityId(1L)
+                        .location("testLocation")
+                        .day(DayOfWeek.MON)
+                        .startTime(LocalTime.parse("13:00"))
+                        .endTime(LocalTime.parse("11:00"))
+                        .build()
+        );
+
+        assertThat(thrown)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("수업 시작 시각이 종료 시각보다 늦습니다.");
+    }
+}


### PR DESCRIPTION
## ✨ 변경 사항 설명
강의 스케줄 검증 시, 검증할 `CourseSchedule`의 갯수대로 DB를 쿼리하는 대신 동일한 교수 또는 강의장의 `CourseSchedule` 목록을 쿼리해 서비스에서 검증하도록 개선.
`CourseService`에서 상황별로 맞는 예외를 던지도록 개선.
`CourseSchedule` 생성 시, 주어진 시작 시각이 종료 시각보다 늦을 경우 예외를 던지도록 개선.
변경사항 테스트에 반영.

## ✅ 체크리스트

- [x] 🏗️ 코드가 **코딩 스타일 가이드**를 준수합니다.
- [x] 🧪 변경 사항에 대한 **테스트가 추가**되었습니다.
- [x] ✅ 모든 **테스트가 정상적으로 통과**합니다.
- [x] 📚 필요한 **문서가 업데이트**되었습니다.

`CourseSchedule` 자정을 넘어가는 수업을 표현할 수 없지만 여기에 대응하기 위해서는 변경해야 할 코드의 범위가 너무 많을 것 같고, 그런 상황 자체가 매우 희귀한 상황이라고 판단되어 우선은 이렇게 수정했습니다.

Closes #118.