### PR TITLE
옥정현/fix 148 한글명 파일이 s3에 업로드되지 않던 인코딩 문제 해결

### DIFF
--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - develop
-      - 옥정현/fix-148
 
     paths:
       - '.github/workflows/**'

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - 옥정현/fix-148
 
     paths:
       - '.github/workflows/**'

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/infra/s3/S3Service.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/infra/s3/S3Service.java
@@ -14,6 +14,7 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
 
 /**
  * AWS S3에 관련된 비즈니스 로직을 처리하는 서비스입니다.
@@ -27,9 +28,13 @@ public class S3Service {
     @Value("${spring.cloud.aws.s3.bucket}")
     private String bucketName;
 
+    // 활성 프로파일 (예: "dev", "prod")
+    @Value("${spring.profiles.active:default}")
+    private String activeProfile;
+
     /**
      * MultipartFile을 S3에 업로드하고, 업로드된 파일의 URL을 반환합니다.
-     * <p>
+     *
      * 업로드된 파일은 S3에 저장되며, URL을 통해 접근할 수 있습니다.
      * S3에 퍼블릭 읽기 권한을 부여하고 고정적인 URL을 부여받기 위해 버킷 정책(Bucket Policy)이 설정되어 있어야 합니다.
      *
@@ -40,7 +45,7 @@ public class S3Service {
     public String upload(MultipartFile file) throws IOException {
 
         // 1) 한글 인코딩 처리 및 공백을 "_"(언더바)로 대체
-        String filename = file.getOriginalFilename();                                  // "자료구조 강의계획서.png"
+        String filename = Optional.ofNullable(file.getOriginalFilename()).orElse("unknown");                                  // "자료구조 강의계획서.png"
         String replacedSpaces = filename.replaceAll("\\s+", "_"); // "자료구조_강의계획서.png"
         String encoded = URLEncoder.encode(replacedSpaces, StandardCharsets.UTF_8);
 
@@ -49,14 +54,12 @@ public class S3Service {
         file.transferTo(filePath.toFile());
 
         // 3) S3에 업로드할 키 생성
-        String key = System.currentTimeMillis() + "_" + file.getOriginalFilename();
+        String timestamp = String.valueOf(System.currentTimeMillis());
+        String key = "%s/%s-%s".formatted(activeProfile, timestamp, encoded); // ex) dev/1684092000000-자료구조_강의계획서.png
 
         // 4) S3에 파일 업로드 (KEY, FILE)
         s3Client.putObject(
-                PutObjectRequest.builder()
-                        .bucket(bucketName)
-                        .key(key)
-                        .build(),
+                PutObjectRequest.builder().bucket(bucketName).key(key).build(),
                 filePath
         );
 

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/infra/s3/S3Service.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/infra/s3/S3Service.java
@@ -55,7 +55,7 @@ public class S3Service {
 
         // 3) S3에 업로드할 키 생성
         String timestamp = String.valueOf(System.currentTimeMillis());
-        String key = "%s/%s-%s".formatted(activeProfile, timestamp, encoded); // ex) dev/1684092000000-자료구조_강의계획서.png
+        String key = "%s/%s-%s".formatted(activeProfile, timestamp, replacedSpaces); // ex) dev/1684092000000-자료구조_강의계획서.png
 
         // 4) S3에 파일 업로드 (KEY, FILE)
         s3Client.putObject(

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/infra/s3/S3Service.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/infra/s3/S3Service.java
@@ -10,6 +10,8 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -38,7 +40,10 @@ public class S3Service {
     public String upload(MultipartFile file) throws IOException {
 
         // 1) 임시 파일 생성
-        Path filePath = Files.createTempFile("up-", "-" + file.getOriginalFilename());
+        String filename = file.getOriginalFilename();
+        String encoded = URLEncoder.encode(filename, StandardCharsets.UTF_8);
+
+        Path filePath = Files.createTempFile("up-", "-" + encoded);
         file.transferTo(filePath.toFile());
 
         // 2) S3에 저장할 키 생성

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/infra/s3/S3Service.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/infra/s3/S3Service.java
@@ -39,17 +39,19 @@ public class S3Service {
      */
     public String upload(MultipartFile file) throws IOException {
 
-        // 1) 임시 파일 생성
-        String filename = file.getOriginalFilename();
-        String encoded = URLEncoder.encode(filename, StandardCharsets.UTF_8);
+        // 1) 한글 인코딩 처리 및 공백을 "_"(언더바)로 대체
+        String filename = file.getOriginalFilename();                                  // "자료구조 강의계획서.png"
+        String replacedSpaces = filename.replaceAll("\\s+", "_"); // "자료구조_강의계획서.png"
+        String encoded = URLEncoder.encode(replacedSpaces, StandardCharsets.UTF_8);
 
+        // 2) 파일을 임시 디렉토리에 저장
         Path filePath = Files.createTempFile("up-", "-" + encoded);
         file.transferTo(filePath.toFile());
 
-        // 2) S3에 저장할 키 생성
+        // 3) S3에 업로드할 키 생성
         String key = System.currentTimeMillis() + "_" + file.getOriginalFilename();
 
-        // S3에 파일 업로드 (KEY, FILE)
+        // 4) S3에 파일 업로드 (KEY, FILE)
         s3Client.putObject(
                 PutObjectRequest.builder()
                         .bucket(bucketName)


### PR DESCRIPTION
## ✨ 변경 사항 설명

맥이나 윈도우에서는 기본으로 utf-8 이 적용되어있어서 업로드에 문제가 없었는데
배포 프로젝트가 실행중인 ec2에는 기본설정이 아니라 오류가 나고 있었음

인코딩해주는 로직을 추가함
+ dev,stg,prod 별로 파일이 구분되어 s3에 저장될 수 있도록 추가함
---
---
⚠️
![image](https://github.com/user-attachments/assets/d99c1701-b0fc-4958-adba-2f08b7ba4101)
develop이랑 merge하다가 실수해서 commit이 겹쳤는데.. 무시하고 사진에 나온 commit 까지만 봐주시면됩니다.
## ✅ 체크리스트

<!-- 📝 완료된 항목은 [x]로 표시해주세요. -->

- [ ] 🏗️ 코드가 **코딩 스타일 가이드**를 준수합니다.
- [ ] 🧪 변경 사항에 대한 **테스트가 추가**되었습니다.
- [ ] ✅ 모든 **테스트가 정상적으로 통과**합니다.
- [ ] 📚 필요한 **문서가 업데이트**되었습니다.

## 🎨 스크린샷 (UI 변경이 있는 경우)

<!-- 🖼️ 변경 전/후 스크린샷을 추가해주세요. -->

## 🛠️ 테스트 방법 (필요시)

<!-- 🧑‍💻 이 PR을 테스트하는 방법을 설명해주세요. -->
