### PR TITLE
Slack 알림 템플릿 개선 및 Redis 중복 알림(10분) 적용·Actuator 잡음 예외 필터링

### DIFF
--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/alert/AlertNotifier.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/alert/AlertNotifier.java
@@ -1,19 +1,26 @@
+// AlertNotifier.java
 package com.WEB4_5_GPT_BE.unihub.global.alert;
 
 import io.sentry.Sentry;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
 public class AlertNotifier {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final StringRedisTemplate redisTemplate;
 
     @Value("${custom.sentry.webhook-url}")
     private String webhookUrl;
@@ -24,73 +31,84 @@ public class AlertNotifier {
     @Value("${custom.slack.duplicate-interval-ms:600000}")
     private long duplicateIntervalMs;
 
-    private final RestTemplate restTemplate = new RestTemplate();
-    private final ConcurrentHashMap<String, Long> recentExceptions = new ConcurrentHashMap<>();
-
-    public void notifyError(String title, Exception e) {
-        if (!activeProfile.equalsIgnoreCase("prod") && !activeProfile.equalsIgnoreCase("stg")) {
-            return; // dev, test, local 등에서는 Slack 알림 전송 안 함
+    /**
+     * 에러 발생 시 Slack에 Block Kit 형식으로 알림 전송
+     */
+    public void notifyError(
+            String title, Exception e, String httpMethod, String path, String params
+    ) {
+        if (!"prod".equalsIgnoreCase(activeProfile) && !"stg".equalsIgnoreCase(activeProfile)) {
+            return;
         }
-
+        // Sentry 전송
         Sentry.captureException(e);
-        String exceptionType = e.getClass().getSimpleName();
-        long now = System.currentTimeMillis();
 
-        Long lastSentTime = recentExceptions.get(exceptionType);
-        if (lastSentTime != null && now - lastSentTime < duplicateIntervalMs) {
+        String exceptionType = e.getClass().getSimpleName();
+        // 중복 알림 제어: Redis TTL 사용
+        String key = "alert:exception:" + exceptionType;
+        Boolean absent = redisTemplate.opsForValue()
+                .setIfAbsent(key, "1", duplicateIntervalMs, TimeUnit.MILLISECONDS);
+        if (!Boolean.TRUE.equals(absent)) {
             return;
         }
 
-        recentExceptions.put(exceptionType, now);
+        // 스택 스니펫 5줄
+        String stackSnippet = Arrays.stream(e.getStackTrace())
+                // 우리의 패키지만
+                .filter(f -> f.getClassName().startsWith("com.WEB4_5_GPT_BE.unihub"))
+                // 최대 5줄
+                .limit(5)
+                .map(StackTraceElement::toString)
+                .collect(Collectors.joining("\n"));
 
-        String fullTitle = "[%s] %s (%s)".formatted(
-                activeProfile.toUpperCase(),
-                title,
-                exceptionType
-        );
-
+        // Slack Block Kit JSON
         String payload = """
+        {
+          "blocks": [
             {
-              "attachments": [
-                {
-                  "color": "danger",
-                  "text": "🚨 *%s*",
-                  "fields": [
-                    {
-                      "title": "Exception Type",
-                      "value": "%s",
-                      "short": true
-                    },
-                    {
-                      "title": "Message",
-                      "value": "%s",
-                      "short": false
-                    }
-                  ],
-                  "ts": "%d"
-                }
+              "type":"header",
+              "text":{"type":"plain_text","text":"🚨 [%s] %s (%s)","emoji":true}
+            },
+            {
+              "type":"section",
+              "fields":[
+                {"type":"mrkdwn","text":"*메시지:*\n%3$s"},
+                {"type":"mrkdwn","text":"*엔드포인트:*\n`%4$s %5$s`"},
+                {"type":"mrkdwn","text":"*파라미터:*\n%6$s"}
               ]
+            },
+            {"type":"divider"},
+            {
+              "type":"section",
+              "text":{"type":"mrkdwn","text":"*스택트레이스 (핵심):*\n```%7$s```"}
             }
-            """.formatted(
-                escape(fullTitle),
-                exceptionType,
-                escape(e.getMessage()),
-                now / 1000
-        );
+          ]
+        }
+        """.formatted(
+                        activeProfile.toUpperCase(),   // %1$s
+                        title,                        // %2$s
+                        escape(e.getMessage()),       // %3$s
+                        httpMethod,                   // %4$s
+                        path,                         // %5$s
+                        escape(params),               // %6$s
+                        escape(stackSnippet)         // %7$s
+                );
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<String> request = new HttpEntity<>(payload, headers);
-
         try {
             restTemplate.postForEntity(webhookUrl, request, String.class);
-        } catch (Exception slackError) {
-            System.err.println("Slack 전송 실패: " + slackError.getMessage());
+        } catch (Exception ex) {
+            System.err.println("Slack 전송 실패: " + ex.getMessage());
         }
     }
 
     private String escape(String input) {
-        return input.replace("\"", "\\\"")
+        if (input == null) return "";
+        return input
+                .replace("\\", "\\\\")
+                .replace("\"", "\\\"")
                 .replace("\n", "\\n")
                 .replace("\r", "");
     }

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/alert/AlertNotifier.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/alert/AlertNotifier.java
@@ -1,4 +1,3 @@
-// AlertNotifier.java
 package com.WEB4_5_GPT_BE.unihub.global.alert;
 
 import io.sentry.Sentry;

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/exception/GlobalExceptionHandler.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.async.AsyncRequestNotUsableException;
 
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -137,5 +138,12 @@ public class GlobalExceptionHandler {
     }
 
     return handleUnihubException( new UnihubException("400", ex.getMessage()) );
+  }
+
+  @ExceptionHandler(AsyncRequestNotUsableException.class)
+  public ResponseEntity<RsData<Void>> handleAsyncNotUsable(AsyncRequestNotUsableException e) {
+    return ResponseEntity
+            .status(HttpStatus.SERVICE_UNAVAILABLE)
+            .body(new RsData<>("503", "서비스를 일시적으로 사용할 수 없습니다.", null));
   }
 }


### PR DESCRIPTION
## ✨ 변경 사항 설명

로그 발생후 Slack 으로 발송시, Slack 전송 탬플릿 변경
redis에 에러 알람 주기 적용(10분간격)
acuactor에서 빈번하게 발생하는 오류 AsyncRequestNotUsableException를 slack과 log에 발송하지 않도록 따로 예외 처리 추가

## ✅ 체크리스트

<!-- 📝 완료된 항목은 [x]로 표시해주세요. -->

- [ ] 🏗️ 코드가 **코딩 스타일 가이드**를 준수합니다.
- [ ] 🧪 변경 사항에 대한 **테스트가 추가**되었습니다.
- [ ] ✅ 모든 **테스트가 정상적으로 통과**합니다.
- [x] 📚 필요한 **문서가 업데이트**되었습니다.

## 🎨 스크린샷 (UI 변경이 있는 경우)

변경 탬플릿
![image](https://github.com/user-attachments/assets/fbbc9d37-1fb9-4ae8-b201-7f8fc8d02192)

## 🛠️ 테스트 방법 (필요시)

<!-- 🧑‍💻 이 PR을 테스트하는 방법을 설명해주세요. -->
