### PR TITLE
squash merge로 인한 사용되지 않는 PR 생성

### DIFF
--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/timetable/controller/TimetableController.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/timetable/controller/TimetableController.java
@@ -3,9 +3,16 @@ package com.WEB4_5_GPT_BE.unihub.domain.timetable.controller;
 
 import com.WEB4_5_GPT_BE.unihub.domain.member.entity.Member;
 import com.WEB4_5_GPT_BE.unihub.domain.timetable.dto.request.TimetableCreateRequest;
+import com.WEB4_5_GPT_BE.unihub.domain.timetable.dto.request.item.TimetableBulkRegisterRequest;
+import com.WEB4_5_GPT_BE.unihub.domain.timetable.dto.request.item.TimetableCourseAddRequest;
+import com.WEB4_5_GPT_BE.unihub.domain.timetable.dto.request.item.TimetableItemNormalCreateRequest;
+import com.WEB4_5_GPT_BE.unihub.domain.timetable.dto.request.item.TimetableItemUpdateRequest;
 import com.WEB4_5_GPT_BE.unihub.domain.timetable.dto.request.share.TimetableShareLinkRequest;
 import com.WEB4_5_GPT_BE.unihub.domain.timetable.dto.response.TimetableDetailResponse;
+import com.WEB4_5_GPT_BE.unihub.domain.timetable.dto.response.item.TimetableItemDetailResponse;
 import com.WEB4_5_GPT_BE.unihub.domain.timetable.dto.response.share.TimetableShareLinkResponse;
+import com.WEB4_5_GPT_BE.unihub.domain.timetable.dto.response.share.TimetableSharedViewResponse;
+import com.WEB4_5_GPT_BE.unihub.domain.timetable.service.TimetableItemService;
 import com.WEB4_5_GPT_BE.unihub.domain.timetable.service.TimetableService;
 import com.WEB4_5_GPT_BE.unihub.global.Rq;
 import com.WEB4_5_GPT_BE.unihub.global.response.Empty;
@@ -27,6 +34,7 @@ import org.springframework.web.bind.annotation.*;
 public class TimetableController {
 
     private final TimetableService timetableService;
+    private final TimetableItemService timetableItemService;
     private final Rq rq;
 
     @Operation(
@@ -90,10 +98,10 @@ public class TimetableController {
     @Operation(
             summary = "공유된 시간표 조회",
             description = """
-                공유 링크(shareKey)를 통해 공개된 시간표를 조회합니다.<br>
-                - 비공개인 경우 403 반환<br>
-                - 만료되었거나 존재하지 않는 경우 404 반환
-            """
+                    공유 링크(shareKey)를 통해 공개된 시간표를 조회합니다.<br>
+                            - 비공개인 경우 403 반환<br>
+                            - 만료되었거나 존재하지 않는 경우 404 반환
+                        """
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "공유된 시간표 조회 성공"),
@@ -101,9 +109,106 @@ public class TimetableController {
             @ApiResponse(responseCode = "404", description = "만료되었거나 존재하지 않는 공유 링크"),
     })
     @GetMapping("/share/{shareKey}")
-    public RsData<?> getSharedTimetable(@PathVariable String shareKey) {
+    public RsData<TimetableSharedViewResponse> getSharedTimetable(@PathVariable String shareKey) {
         Member member = rq.getActor();
         var response = timetableService.getSharedTimetable(shareKey, member);
         return new RsData<>("200", "공유된 시간표 조회 성공", response);
+    }
+
+    @Operation(
+            summary = "시간표 수정 항목 등록",
+            description = "시간표에 일반 항목(사용자 정의 항목)을 추가합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "항목 등록 성공"),
+            @ApiResponse(responseCode = "403", description = "본인의 시간표가 아님"),
+            @ApiResponse(responseCode = "404", description = "시간표가 존재하지 않음")
+    })
+    @PostMapping("/normal")
+    public RsData<Empty> createNormalItem(@RequestBody TimetableItemNormalCreateRequest request) {
+        Member actor = rq.getActor();
+        timetableItemService.createNormalItem(actor, request);
+        return new RsData<>("201", "시간표 일정이 성공적으로 등록되었습니다.");
+    }
+
+    @Operation(
+            summary = "시간표에 강의 등록",
+            description = "시간표에 강의 항목을 추가합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "강의 항목 등록 성공"),
+            @ApiResponse(responseCode = "403", description = "본인의 시간표가 아님"),
+            @ApiResponse(responseCode = "404", description = "시간표 또는 강의가 존재하지 않음"),
+            @ApiResponse(responseCode = "409", description = "이미 등록된 강의"
+            )
+    })
+    @PostMapping("/course")
+    public RsData<Empty> addCourseItem(@RequestBody TimetableCourseAddRequest request) {
+        Member actor = rq.getActor();
+        timetableItemService.addCourseItem(actor, request);
+        return new RsData<>("201", "강의가 시간표에 성공적으로 등록되었습니다.");
+    }
+
+    @Operation(
+            summary = "내 강의 목록으로 시간표 일괄 등록",
+            description = "내 수강신청 정보를 기반으로 시간표에 강의 항목을 일괄 등록합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "일괄 등록 성공"),
+            @ApiResponse(responseCode = "404", description = "시간표가 존재하지 않음")
+    })
+    @PostMapping("/bulk")
+    public RsData<Empty> bulkRegisterFromEnrollment(@RequestBody TimetableBulkRegisterRequest request) {
+        Member member = rq.getActor();
+        timetableItemService.bulkRegisterFromEnrollment(member, request);
+        return new RsData<>("201", "시간표에 반영되었습니다.");
+    }
+
+    @Operation(
+            summary = "시간표 항목 단건 조회",
+            description = "시간표 항목을 단건 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "항목 조회 성공"),
+            @ApiResponse(responseCode = "403", description = "본인의 시간표가 아님"),
+            @ApiResponse(responseCode = "404", description = "항목이 존재하지 않음")
+    })
+    @GetMapping("/{timetableItemId}")
+    public RsData<TimetableItemDetailResponse> getItemDetail(@PathVariable Long timetableItemId) {
+        Member actor = rq.getActor();
+        TimetableItemDetailResponse response = timetableItemService.getItemDetail(actor, timetableItemId);
+        return new RsData<>("200", "시간표 항목 조회 성공", response);
+    }
+
+    @Operation(
+            summary = "시간표 항목 수정",
+            description = "시간표 항목을 수정합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "항목 수정 성공"),
+            @ApiResponse(responseCode = "403", description = "본인의 시간표가 아님"),
+            @ApiResponse(responseCode = "404", description = "항목이 존재하지 않음")
+    })
+    @PutMapping("/{timetableItemId}")
+    public RsData<Empty> updateItem(@PathVariable Long timetableItemId, @RequestBody TimetableItemUpdateRequest request) {
+        Member actor = rq.getActor();
+        timetableItemService.updateItem(actor, timetableItemId, request);
+        return new RsData<>("200", "시간표 항목이 성공적으로 수정되었습니다.");
+    }
+
+    @Operation(
+            summary = "시간표 항목 삭제",
+            description = "시간표 항목을 삭제합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "항목 삭제 성공"),
+            @ApiResponse(responseCode = "403", description = "본인의 시간표가 아님"),
+            @ApiResponse(responseCode = "404", description = "항목이 존재하지 않음")
+    })
+    @DeleteMapping("/{timetableItemId}")
+    public RsData<Empty> deleteItem(@PathVariable Long timetableItemId) {
+        Member actor = rq.getActor();
+        timetableItemService.deleteItem(actor, timetableItemId);
+        return new RsData<>("200", "시간표가 성공적으로 삭제되었습니다.");
     }
 }

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/timetable/dto/request/item/TimetableBulkRegisterRequest.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/timetable/dto/request/item/TimetableBulkRegisterRequest.java
@@ -1,0 +1,15 @@
+package com.WEB4_5_GPT_BE.unihub.domain.timetable.dto.request.item;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record TimetableBulkRegisterRequest(
+        @NotNull(message = "시간표 항목 ID는 필수입니다.")
+        Long timetableId,
+        @NotNull(message = "강의 ID 리스트는 필수입니다.")
+        List<Long> courseIds,
+        String color,
+        String memo
+) {
+}

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/timetable/dto/request/item/TimetableItemUpdateRequest.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/timetable/dto/request/item/TimetableItemUpdateRequest.java
@@ -1,0 +1,40 @@
+package com.WEB4_5_GPT_BE.unihub.domain.timetable.dto.request.item;
+
+import com.WEB4_5_GPT_BE.unihub.domain.common.enums.TimetableItemType;
+import com.WEB4_5_GPT_BE.unihub.domain.course.dto.CourseScheduleDto;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record TimetableItemUpdateRequest(
+
+
+        @NotBlank(message = "유형은 필수입니다.")
+        TimetableItemType type,
+
+        @NotBlank(message = "강의 ID는 필수입니다.")
+        Long courseId,
+
+        @NotBlank(message = "제목은 필수입니다.")
+        String title,
+
+        @NotBlank(message = "교수명은 필수입니다.")
+        String professorName,
+
+        @NotBlank(message = "색상은 필수입니다.")
+        String color,
+
+        @Size(max = 300, message = "메모는 최대 300자까지 입력할 수 있습니다.")
+        String memo,
+
+        String location,
+
+        @NotNull(message = "스케줄은 필수입니다.")
+        @Size(min = 1, message = "스케줄은 최소 1개 이상이어야 합니다.")
+        List<@Valid CourseScheduleDto> schedule
+
+) {
+}

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/timetable/exception/DuplicateCourseItemException.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/timetable/exception/DuplicateCourseItemException.java
@@ -1,0 +1,10 @@
+package com.WEB4_5_GPT_BE.unihub.domain.timetable.exception;
+
+/**
+ * 이미 등록된 강의를 다시 추가하려고 할 때 발생하는 예외
+ */
+public class DuplicateCourseItemException extends TimetableException {
+    public DuplicateCourseItemException() {
+        super("409", "해당 강의는 이미 시간표에 등록되어 있습니다.");
+    }
+}

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/timetable/exception/TimetableItemNotFoundException.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/timetable/exception/TimetableItemNotFoundException.java
@@ -1,0 +1,10 @@
+package com.WEB4_5_GPT_BE.unihub.domain.timetable.exception;
+
+/**
+ * 시간표 항목을 찾을 수 없는 경우 발생하는 예외
+ */
+public class TimetableItemNotFoundException extends TimetableException {
+    public TimetableItemNotFoundException() {
+        super("404", "해당 시간표 항목을 찾을 수 없습니다.");
+    }
+}

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/timetable/exception/TimetableNotFoundException.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/timetable/exception/TimetableNotFoundException.java
@@ -1,0 +1,10 @@
+package com.WEB4_5_GPT_BE.unihub.domain.timetable.exception;
+
+/**
+ * 시간표를 찾을 수 없는 경우 발생하는 예외
+ */
+public class TimetableNotFoundException extends TimetableException {
+    public TimetableNotFoundException() {
+        super("404", "시간표를 찾을 수 없습니다.");
+    }
+}

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/timetable/exception/TimetableUnauthorizedException.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/timetable/exception/TimetableUnauthorizedException.java
@@ -1,0 +1,10 @@
+package com.WEB4_5_GPT_BE.unihub.domain.timetable.exception;
+
+/**
+ * 시간표 소유자가 아닌 사용자가 접근 시 발생하는 예외
+ */
+public class TimetableUnauthorizedException extends TimetableException {
+    public TimetableUnauthorizedException() {
+        super("401", "잘못된 사용자입니다.");
+    }
+}

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/timetable/repository/TimetableItemRepository.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/timetable/repository/TimetableItemRepository.java
@@ -1,11 +1,13 @@
 package com.WEB4_5_GPT_BE.unihub.domain.timetable.repository;
 
+import com.WEB4_5_GPT_BE.unihub.domain.course.entity.Course;
 import com.WEB4_5_GPT_BE.unihub.domain.timetable.entity.TimetableItem;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface TimetableItemRepository extends JpaRepository<TimetableItem, Long> {
 
@@ -13,4 +15,18 @@ public interface TimetableItemRepository extends JpaRepository<TimetableItem, Lo
             "LEFT JOIN FETCH ti.schedules " +
             "WHERE ti.timetable.id = :timetableId")
     List<TimetableItem> findWithSchedulesByTimetableId(@Param("timetableId") Long timetableId);
+
+    // 시간표 항목 상세 조회
+    @Query("SELECT ti FROM TimetableItem ti " +
+            "LEFT JOIN FETCH ti.schedules " +
+            "WHERE ti.id = :itemId")
+    Optional<TimetableItem> findWithSchedulesById(@Param("itemId") Long itemId);
+
+    // 특정 시간표에 등록된 강의 조회
+    Optional<TimetableItem> findByTimetableIdAndCourse(Long timetableId, Course course);
+
+    // 특정 멤버가 시간표 항목 소유 여부 확인
+    @Query("SELECT COUNT(ti) > 0 FROM TimetableItem ti " +
+            "WHERE ti.id = :itemId AND ti.timetable.member.id = :memberId")
+    boolean existsByIdAndMemberId(@Param("itemId") Long itemId, @Param("memberId") Long memberId);
 }

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/timetable/service/TimetableItemService.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/timetable/service/TimetableItemService.java
@@ -1,21 +1,22 @@
 package com.WEB4_5_GPT_BE.unihub.domain.timetable.service;
 
 import com.WEB4_5_GPT_BE.unihub.domain.member.entity.Member;
+import com.WEB4_5_GPT_BE.unihub.domain.timetable.dto.request.item.TimetableBulkRegisterRequest;
 import com.WEB4_5_GPT_BE.unihub.domain.timetable.dto.request.item.TimetableCourseAddRequest;
 import com.WEB4_5_GPT_BE.unihub.domain.timetable.dto.request.item.TimetableItemNormalCreateRequest;
+import com.WEB4_5_GPT_BE.unihub.domain.timetable.dto.request.item.TimetableItemUpdateRequest;
 import com.WEB4_5_GPT_BE.unihub.domain.timetable.dto.response.item.TimetableItemDetailResponse;
-import com.WEB4_5_GPT_BE.unihub.domain.timetable.dto.response.item.TimetableItemUpdateRequest;
 
 public interface TimetableItemService {
 
     // 시간표에 직접 등록
-    void addCustomItem(Member member, TimetableItemNormalCreateRequest request);
+    void createNormalItem(Member member, TimetableItemNormalCreateRequest request);
 
     // 시간표에 강의 등록
     void addCourseItem(Member member, TimetableCourseAddRequest request);
 
     // 수강 중인 강의 전체 반영
-    void bulkRegisterFromEnrollment(Member member);
+    void bulkRegisterFromEnrollment(Member member, TimetableBulkRegisterRequest request);
 
     // 시간표 항목 단건 조회
     TimetableItemDetailResponse getItemDetail(Member member, Long timetableItemId);

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/timetable/service/TimetableItemServiceImpl.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/timetable/service/TimetableItemServiceImpl.java
@@ -1,45 +1,328 @@
 package com.WEB4_5_GPT_BE.unihub.domain.timetable.service;
 
+import com.WEB4_5_GPT_BE.unihub.domain.common.enums.DayOfWeek;
+import com.WEB4_5_GPT_BE.unihub.domain.common.enums.TimetableItemType;
+import com.WEB4_5_GPT_BE.unihub.domain.course.dto.CourseScheduleDto;
+import com.WEB4_5_GPT_BE.unihub.domain.course.entity.Course;
+import com.WEB4_5_GPT_BE.unihub.domain.course.entity.CourseSchedule;
+import com.WEB4_5_GPT_BE.unihub.domain.course.exception.CourseNotFoundException;
+import com.WEB4_5_GPT_BE.unihub.domain.course.repository.CourseRepository;
 import com.WEB4_5_GPT_BE.unihub.domain.member.entity.Member;
+import com.WEB4_5_GPT_BE.unihub.domain.timetable.dto.request.item.TimetableBulkRegisterRequest;
 import com.WEB4_5_GPT_BE.unihub.domain.timetable.dto.request.item.TimetableCourseAddRequest;
 import com.WEB4_5_GPT_BE.unihub.domain.timetable.dto.request.item.TimetableItemNormalCreateRequest;
+import com.WEB4_5_GPT_BE.unihub.domain.timetable.dto.request.item.TimetableItemUpdateRequest;
 import com.WEB4_5_GPT_BE.unihub.domain.timetable.dto.response.item.TimetableItemDetailResponse;
-import com.WEB4_5_GPT_BE.unihub.domain.timetable.dto.response.item.TimetableItemUpdateRequest;
+import com.WEB4_5_GPT_BE.unihub.domain.timetable.entity.Timetable;
+import com.WEB4_5_GPT_BE.unihub.domain.timetable.entity.TimetableItem;
+import com.WEB4_5_GPT_BE.unihub.domain.timetable.entity.TimetableItemSchedule;
+import com.WEB4_5_GPT_BE.unihub.domain.timetable.exception.DuplicateCourseItemException;
+import com.WEB4_5_GPT_BE.unihub.domain.timetable.exception.TimetableItemNotFoundException;
+import com.WEB4_5_GPT_BE.unihub.domain.timetable.exception.TimetableNotFoundException;
+import com.WEB4_5_GPT_BE.unihub.domain.timetable.exception.TimetableUnauthorizedException;
+import com.WEB4_5_GPT_BE.unihub.domain.timetable.repository.TimetableItemRepository;
+import com.WEB4_5_GPT_BE.unihub.domain.timetable.repository.TimetableRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class TimetableItemServiceImpl implements TimetableItemService {
-    @Override
-    public void addCustomItem(Member member, TimetableItemNormalCreateRequest request) {
 
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+    private final TimetableRepository timetableRepository;
+    private final TimetableItemRepository timetableItemRepository;
+    private final CourseRepository courseRepository;
+
+    /**
+     * 시간표에 사용자 정의 항목 추가
+     */
+    @Override
+    @Transactional
+    public void createNormalItem(Member member, TimetableItemNormalCreateRequest request) {
+        // 시간표 조회
+        Timetable timetable = timetableRepository.findById(request.timetableId())
+                .orElseThrow(TimetableNotFoundException::new);
+
+        // 시간표 소유자 확인
+        if (!timetable.getMember().getId().equals(member.getId())) {
+            throw new TimetableUnauthorizedException();
+        }
+
+        // 시간표 항목 생성
+        TimetableItem timetableItem = TimetableItem.builder()
+                .timetable(timetable)
+                .type(TimetableItemType.NORMAL)
+                .title(request.title())
+                .professorName(request.professorName())
+                .color(request.color())
+                .location(request.location())
+                .memo(request.memo())
+                .build();
+
+        // 시간표 항목 저장
+        TimetableItem savedItem = timetableItemRepository.save(timetableItem);
+
+        // 스케줄 정보 추가
+        for (TimetableItemNormalCreateRequest.ScheduleRequest scheduleRequest : request.schedule()) {
+            TimetableItemSchedule schedule = TimetableItemSchedule.builder()
+                    .timetableItem(savedItem)
+                    .day(scheduleRequest.day())
+                    .startTime(LocalTime.parse(scheduleRequest.startTime(), TIME_FORMATTER))
+                    .endTime(LocalTime.parse(scheduleRequest.endTime(), TIME_FORMATTER))
+                    .build();
+
+            // 연관 관계를 통해 자동으로 저장될 수 있도록 추가
+            savedItem.getSchedules().add(schedule);
+        }
     }
 
+    /**
+     * 시간표에 강의 추가
+     */
     @Override
+    @Transactional
     public void addCourseItem(Member member, TimetableCourseAddRequest request) {
+        // 시간표 조회
+        Timetable timetable = timetableRepository.findById(request.timetableId())
+                .orElseThrow(TimetableNotFoundException::new);
 
+        // 시간표 소유자 확인
+        if (!timetable.getMember().getId().equals(member.getId())) {
+            throw new TimetableUnauthorizedException();
+        }
+
+        // 강의 조회
+        Course course = courseRepository.findById(request.courseId())
+                .orElseThrow(CourseNotFoundException::new);
+
+        // 이미 등록된 강의인지 확인
+        Optional<TimetableItem> existingItem = timetableItemRepository.findByTimetableIdAndCourse(timetable.getId(), course);
+        if (existingItem.isPresent()) {
+            throw new DuplicateCourseItemException();
+        }
+
+        // 시간표 항목 생성
+        TimetableItem timetableItem = TimetableItem.builder()
+                .timetable(timetable)
+                .course(course)
+                .type(TimetableItemType.COURSE)
+                .title(course.getTitle())
+                .professorName(course.getProfessor().getName())
+                .color(request.color())
+                .location(course.getLocation())
+                .memo(request.memo())
+                .build();
+
+        // 시간표 항목 저장
+        TimetableItem savedItem = timetableItemRepository.save(timetableItem);
+
+        // 강의 스케줄 정보 추가
+        for (CourseSchedule courseSchedule : course.getSchedules()) {
+            TimetableItemSchedule schedule = TimetableItemSchedule.builder()
+                    .timetableItem(savedItem)
+                    .day(courseSchedule.getDay())
+                    .startTime(courseSchedule.getStartTime())
+                    .endTime(courseSchedule.getEndTime())
+                    .build();
+
+            savedItem.getSchedules().add(schedule);
+        }
     }
 
+    /**
+     * 수강 중인 강의 전체 반영
+     */
     @Override
-    public void bulkRegisterFromEnrollment(Member member) {
+    @Transactional
+    public void bulkRegisterFromEnrollment(Member member, TimetableBulkRegisterRequest request) {
+        // 요청에서 시간표 ID와 강의 ID 목록 가져오기
+        Long timetableId = request.timetableId();
+        List<Long> courseIds = request.courseIds();
 
+        if (courseIds == null || courseIds.isEmpty()) {
+            return; // 등록할 강의가 없으면 처리할 것 없음
+        }
+
+        // 시간표 조회 (권한 확인)
+        Timetable timetable = timetableRepository.findById(timetableId)
+                .orElseThrow(TimetableNotFoundException::new);
+
+        // 권한 확인 (본인 시간표인지)
+        if (!timetable.getMember().getId().equals(member.getId())) {
+            throw new TimetableUnauthorizedException();
+        }
+
+        // 현재 시간표에 등록된 강의 항목 조회
+        List<TimetableItem> existingItems = timetableItemRepository.findWithSchedulesByTimetableId(timetable.getId());
+        List<Course> existingCourses = existingItems.stream()
+                .map(TimetableItem::getCourse)
+                .filter(Objects::nonNull)
+                .toList();
+
+        // 요청에 포함된 각 강의 ID에 대해 강의를 조회하고 시간표에 추가
+        for (Long courseId : courseIds) {
+            // 강의 조회
+            Course course = courseRepository.findById(courseId)
+                    .orElseThrow(CourseNotFoundException::new);
+
+            // 이미 등록된 강의라면 건너뛔
+            if (existingCourses.contains(course)) {
+                continue;
+            }
+
+            // 항목 생성 및 저장
+            TimetableItem item = TimetableItem.builder()
+                    .timetable(timetable)
+                    .course(course)
+                    .type(TimetableItemType.COURSE)
+                    .title(course.getTitle())
+                    .professorName(course.getProfessor().getName())
+                    .color(generateRandomColor()) // 랜덤 색상 생성
+                    .location(course.getLocation())
+                    .build();
+
+            TimetableItem savedItem = timetableItemRepository.save(item);
+
+            // 강의 스케줄 정보 추가
+            for (CourseSchedule courseSchedule : course.getSchedules()) {
+                TimetableItemSchedule schedule = TimetableItemSchedule.builder()
+                        .timetableItem(savedItem)
+                        .day(courseSchedule.getDay())
+                        .startTime(courseSchedule.getStartTime())
+                        .endTime(courseSchedule.getEndTime())
+                        .build();
+
+                savedItem.getSchedules().add(schedule);
+            }
+        }
     }
 
+    /**
+     * 시간표 항목 단건 조회
+     */
     @Override
     public TimetableItemDetailResponse getItemDetail(Member member, Long timetableItemId) {
-        return null;
+        // 시간표 항목 조회
+        TimetableItem timetableItem = timetableItemRepository.findWithSchedulesById(timetableItemId)
+                .orElseThrow(TimetableItemNotFoundException::new);
+
+        // 시간표 소유자 확인
+        if (!timetableItem.getTimetable().getMember().getId().equals(member.getId())) {
+            throw new TimetableUnauthorizedException();
+        }
+
+        Timetable timetable = timetableItem.getTimetable();
+
+        // 스케줄 정보 변환
+        List<TimetableItemDetailResponse.ScheduleDto> schedules = timetableItem.getSchedules().stream()
+                .map(schedule -> new TimetableItemDetailResponse.ScheduleDto(
+                        schedule.getDay().toString(),
+                        schedule.getStartTime().format(TIME_FORMATTER),
+                        schedule.getEndTime().format(TIME_FORMATTER)
+                ))
+                .collect(Collectors.toList());
+
+        // 응답 DTO 반환
+        return new TimetableItemDetailResponse(
+                timetable.getYear(),
+                timetable.getSemester(),
+                timetableItem.getTitle(),
+                timetableItem.getProfessorName(),
+                timetableItem.getLocation(),
+                timetableItem.getColor(),
+                timetableItem.getMemo(),
+                schedules
+        );
     }
 
+    /**
+     * 시간표 항목 수정
+     */
     @Override
+    @Transactional
     public void updateItem(Member member, Long timetableItemId, TimetableItemUpdateRequest request) {
+        // 시간표 항목 조회
+        TimetableItem timetableItem = timetableItemRepository.findWithSchedulesById(timetableItemId)
+                .orElseThrow(TimetableItemNotFoundException::new);
 
+        // 시간표 소유자 확인
+        if (!timetableItem.getTimetable().getMember().getId().equals(member.getId())) {
+            throw new TimetableUnauthorizedException();
+        }
+
+        // 기본 정보 업데이트
+        timetableItem.setTitle(request.title());
+        timetableItem.setProfessorName(request.professorName());
+        timetableItem.setColor(request.color());
+        timetableItem.setLocation(request.location());
+        timetableItem.setMemo(request.memo());
+
+        // 강의인 경우 수정가능한 값만 업데이트
+        if (timetableItem.getType() == TimetableItemType.COURSE) {
+            // 강의의 경우 시간표 스케줄 정보는 강의 정보에 맞춰 개인 설정 불가
+            return;
+        }
+
+        // 기존 스케줄 삭제
+        timetableItem.getSchedules().clear();
+
+        // 새 스케줄 추가
+        for (CourseScheduleDto scheduleDto : request.schedule()) {
+            DayOfWeek day = scheduleDto.day();
+            LocalTime startTime = LocalTime.parse(scheduleDto.startTime(), TIME_FORMATTER);
+            LocalTime endTime = LocalTime.parse(scheduleDto.endTime(), TIME_FORMATTER);
+
+            TimetableItemSchedule schedule = TimetableItemSchedule.builder()
+                    .timetableItem(timetableItem)
+                    .day(day)
+                    .startTime(startTime)
+                    .endTime(endTime)
+                    .build();
+
+            timetableItem.getSchedules().add(schedule);
+        }
     }
 
+    /**
+     * 시간표 항목 삭제
+     */
     @Override
+    @Transactional
     public void deleteItem(Member member, Long timetableItemId) {
+        // 해당 항목을 소유한 멤버인지 확인
+        boolean isOwnedByMember = timetableItemRepository.existsByIdAndMemberId(timetableItemId, member.getId());
 
+        if (!isOwnedByMember) {
+            throw new TimetableUnauthorizedException();
+        }
+
+        // 항목 삭제 (연결된 스케줄 기록도 케스케이드로 함께 삭제됨)
+        timetableItemRepository.deleteById(timetableItemId);
+    }
+
+    /**
+     * 랜덤 색상 생성 함수
+     */
+    private String generateRandomColor() {
+        // 시간표용 다양한 색상 목록
+        List<String> colors = List.of(
+                "#4285F4", "#EA4335", "#FBBC05", "#34A853",
+                "#3498DB", "#9B59B6", "#E74C3C", "#E67E22", "#F1C40F",
+                "#1ABC9C", "#2ECC71", "#FF6B6B", "#747D8C", "#5F27CD"
+        );
+
+        // 랜덤 색상 선택
+        int randomIndex = (int) (Math.random() * colors.size());
+        return colors.get(randomIndex);
     }
 }

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/alert/AlertNotifier.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/alert/AlertNotifier.java
@@ -3,17 +3,23 @@ package com.WEB4_5_GPT_BE.unihub.global.alert;
 import io.sentry.Sentry;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
 public class AlertNotifier {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final StringRedisTemplate redisTemplate;
 
     @Value("${custom.sentry.webhook-url}")
     private String webhookUrl;
@@ -24,73 +30,84 @@ public class AlertNotifier {
     @Value("${custom.slack.duplicate-interval-ms:600000}")
     private long duplicateIntervalMs;
 
-    private final RestTemplate restTemplate = new RestTemplate();
-    private final ConcurrentHashMap<String, Long> recentExceptions = new ConcurrentHashMap<>();
-
-    public void notifyError(String title, Exception e) {
-        if (!activeProfile.equalsIgnoreCase("prod") && !activeProfile.equalsIgnoreCase("stg")) {
-            return; // dev, test, local 등에서는 Slack 알림 전송 안 함
+    /**
+     * 에러 발생 시 Slack에 Block Kit 형식으로 알림 전송
+     */
+    public void notifyError(
+            String title, Exception e, String httpMethod, String path, String params
+    ) {
+        if (!"prod".equalsIgnoreCase(activeProfile) && !"stg".equalsIgnoreCase(activeProfile)) {
+            return;
         }
-
+        // Sentry 전송
         Sentry.captureException(e);
-        String exceptionType = e.getClass().getSimpleName();
-        long now = System.currentTimeMillis();
 
-        Long lastSentTime = recentExceptions.get(exceptionType);
-        if (lastSentTime != null && now - lastSentTime < duplicateIntervalMs) {
+        String exceptionType = e.getClass().getSimpleName();
+        // 중복 알림 제어: Redis TTL 사용
+        String key = "alert:exception:" + exceptionType;
+        Boolean absent = redisTemplate.opsForValue()
+                .setIfAbsent(key, "1", duplicateIntervalMs, TimeUnit.MILLISECONDS);
+        if (!Boolean.TRUE.equals(absent)) {
             return;
         }
 
-        recentExceptions.put(exceptionType, now);
+        // 스택 스니펫 5줄
+        String stackSnippet = Arrays.stream(e.getStackTrace())
+                // 우리의 패키지만
+                .filter(f -> f.getClassName().startsWith("com.WEB4_5_GPT_BE.unihub"))
+                // 최대 5줄
+                .limit(5)
+                .map(StackTraceElement::toString)
+                .collect(Collectors.joining("\n"));
 
-        String fullTitle = "[%s] %s (%s)".formatted(
-                activeProfile.toUpperCase(),
-                title,
-                exceptionType
-        );
-
+        // Slack Block Kit JSON
         String payload = """
+        {
+          "blocks": [
             {
-              "attachments": [
-                {
-                  "color": "danger",
-                  "text": "🚨 *%s*",
-                  "fields": [
-                    {
-                      "title": "Exception Type",
-                      "value": "%s",
-                      "short": true
-                    },
-                    {
-                      "title": "Message",
-                      "value": "%s",
-                      "short": false
-                    }
-                  ],
-                  "ts": "%d"
-                }
+              "type":"header",
+              "text":{"type":"plain_text","text":"🚨 [%s] %s (%s)","emoji":true}
+            },
+            {
+              "type":"section",
+              "fields":[
+                {"type":"mrkdwn","text":"*메시지:*\n%3$s"},
+                {"type":"mrkdwn","text":"*엔드포인트:*\n`%4$s %5$s`"},
+                {"type":"mrkdwn","text":"*파라미터:*\n%6$s"}
               ]
+            },
+            {"type":"divider"},
+            {
+              "type":"section",
+              "text":{"type":"mrkdwn","text":"*스택트레이스 (핵심):*\n```%7$s```"}
             }
-            """.formatted(
-                escape(fullTitle),
-                exceptionType,
-                escape(e.getMessage()),
-                now / 1000
+          ]
+        }
+        """.formatted(
+                activeProfile.toUpperCase(),   // %1$s
+                title,                        // %2$s
+                escape(e.getMessage()),       // %3$s
+                httpMethod,                   // %4$s
+                path,                         // %5$s
+                escape(params),               // %6$s
+                escape(stackSnippet)         // %7$s
         );
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<String> request = new HttpEntity<>(payload, headers);
-
         try {
             restTemplate.postForEntity(webhookUrl, request, String.class);
-        } catch (Exception slackError) {
-            System.err.println("Slack 전송 실패: " + slackError.getMessage());
+        } catch (Exception ex) {
+            System.err.println("Slack 전송 실패: " + ex.getMessage());
         }
     }
 
     private String escape(String input) {
-        return input.replace("\"", "\\\"")
+        if (input == null) return "";
+        return input
+                .replace("\\", "\\\\")
+                .replace("\"", "\\\"")
                 .replace("\n", "\\n")
                 .replace("\r", "");
     }

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/exception/GlobalExceptionHandler.java
@@ -4,10 +4,13 @@ import com.WEB4_5_GPT_BE.unihub.domain.member.exception.auth.AccessTokenExpiredE
 import com.WEB4_5_GPT_BE.unihub.global.alert.AlertNotifier;
 import com.WEB4_5_GPT_BE.unihub.global.response.RsData;
 import jakarta.persistence.EntityNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.hibernate.LazyInitializationException;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
@@ -16,7 +19,9 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.async.AsyncRequestNotUsableException;
 
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -24,65 +29,121 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class GlobalExceptionHandler {
 
-  private final AlertNotifier alertNotifier;
+    private final AlertNotifier alertNotifier;
+    private final HttpServletRequest request;
 
-  @ExceptionHandler(UnihubException.class)
-  public ResponseEntity<RsData<Void>> handleUnihubException(UnihubException e) {
-    return ResponseEntity.status(e.getStatusCode())
-            .body(new RsData<>(e.getCode(), e.getMessage()));
-  }
-
-  @ExceptionHandler(MethodArgumentNotValidException.class)
-  public ResponseEntity<RsData<Void>> handleValidationException(MethodArgumentNotValidException e) {
-    String message = e.getBindingResult().getFieldErrors().stream()
-            .map(FieldError::getDefaultMessage)
-            .collect(Collectors.joining(", "));
-    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-            .body(new RsData<>("400", message.isBlank() ? "잘못된 요청입니다." : message, null));
-  }
-
-  @ExceptionHandler({ AuthenticationException.class, AccessDeniedException.class })
-  public ResponseEntity<RsData<Void>> handleAuthorizationExceptions(Exception e) {
-    if (e instanceof AuthenticationException) {
-      return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-              .body(new RsData<>("401", "로그인이 필요합니다.", null));
-    }
-    if (e instanceof AccessDeniedException) {
-      return ResponseEntity.status(HttpStatus.FORBIDDEN)
-              .body(new RsData<>("403", "권한이 없습니다.", null));
-    }
-    return ResponseEntity.status(HttpStatus.FORBIDDEN)
-            .body(new RsData<>("403", "접근이 제한되었습니다.", null));
-  }
-
-  @ExceptionHandler(EntityNotFoundException.class)
-  public ResponseEntity<RsData<Void>> handleEntityNotFoundException(EntityNotFoundException e) {
-    return ResponseEntity.status(HttpStatus.NOT_FOUND)
-            .body(new RsData<>("404", "존재하지 않는 사용자입니다.", null));
-  }
-
-  @ExceptionHandler({ LazyInitializationException.class, RuntimeException.class, Exception.class })
-  public ResponseEntity<RsData<Void>> handleServerError(Exception e) {
-    log.error("🔥 500 Internal Server Error", e);
-    alertNotifier.notifyError("500 서버 내부 오류", e);
-    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-            .body(new RsData<>("500", "서버 오류가 발생했습니다.", null));
-  }
-
-  @ExceptionHandler(AccessTokenExpiredException.class)
-  public ResponseEntity<RsData<Void>> handleAccessTokenExpiredException(AccessTokenExpiredException e) {
-    return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-            .body(new RsData<>("401-1", e.getMessage(), null));
-  }
-
-  @ExceptionHandler(MissingRequestHeaderException.class)
-  public ResponseEntity<RsData<Void>> handleMissingHeader(MissingRequestHeaderException ex) {
-    if ("X-Client-Base-Url".equals(ex.getHeaderName())) {
-      return handleUnihubException(
-              new UnihubException("400", "X-Client-Base-Url 헤더가 필요합니다.")
-      );
+    @ExceptionHandler(UnihubException.class)
+    public ResponseEntity<RsData<Void>> handleUnihubException(UnihubException e) {
+        return ResponseEntity.status(e.getStatusCode())
+                .body(new RsData<>(e.getCode(), e.getMessage()));
     }
 
-    return handleUnihubException( new UnihubException("400", ex.getMessage()) );
-  }
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<RsData<Void>> handleValidationException(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .map(FieldError::getDefaultMessage)
+                .collect(Collectors.joining(", "));
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new RsData<>("400", message.isBlank() ? "잘못된 요청입니다." : message, null));
+    }
+
+    @ExceptionHandler({ AuthenticationException.class, AccessDeniedException.class })
+    public ResponseEntity<RsData<Void>> handleAuthorizationExceptions(Exception e) {
+        if (e instanceof AuthenticationException) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(new RsData<>("401", "로그인이 필요합니다.", null));
+        }
+        if (e instanceof AccessDeniedException) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(new RsData<>("403", "권한이 없습니다.", null));
+        }
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(new RsData<>("403", "접근이 제한되었습니다.", null));
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<RsData<Void>> handleEntityNotFoundException(EntityNotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(new RsData<>("404", "존재하지 않는 사용자입니다.", null));
+    }
+
+    @ExceptionHandler({ LazyInitializationException.class, RuntimeException.class, Exception.class })
+    public ResponseEntity<RsData<Void>> handleServerError(Exception e) {
+        log.error("🔥 500 Internal Server Error", e);
+
+        // ① 요청 메서드·경로
+        String method = request.getMethod();
+        String path   = request.getRequestURI();
+
+        // ② 파라미터 JSON (body나 쿼리)
+        String paramJson = extractParams(request); // 아래 유틸 참조
+
+        alertNotifier.notifyError(
+                "500 서버 내부 오류",
+                e,
+                method,
+                path,
+                paramJson
+        );
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new RsData<>("500", "서버 오류가 발생했습니다.", null));
+    }
+
+    private String extractParams(HttpServletRequest req) {
+        String contentType = req.getContentType() == null ? "" : req.getContentType();
+
+        // 1) application/json
+        if (contentType.contains(MediaType.APPLICATION_JSON_VALUE)) {
+            String json = (String) req.getAttribute("cachedRequestBody");
+            return (json != null)
+                    ? StringUtils.abbreviate(json, 300)
+                    : "(빈 JSON 바디)";
+        }
+
+        // 2) GET 요청 → 쿼리스트링
+        if ("GET".equalsIgnoreCase(req.getMethod())) {
+            String qs = req.getQueryString();
+            return (qs != null && !qs.isBlank())
+                    ? qs
+                    : "(쿼리스트링 없음)";
+        }
+
+        // 3) 폼데이터 (x-www-form-urlencoded or multipart/form-data)
+        Map<String, String[]> map = req.getParameterMap();
+        if (!map.isEmpty()) {
+            return map.entrySet().stream()
+                    .map(e -> {
+                        String key = e.getKey();
+                        String[] vals = e.getValue();
+                        return key + ":" + String.join(",", vals);
+                    })
+                    .collect(Collectors.joining("\n"));
+        }
+
+        return "(파라미터 없음)";
+    }
+
+    @ExceptionHandler(AccessTokenExpiredException.class)
+    public ResponseEntity<RsData<Void>> handleAccessTokenExpiredException(AccessTokenExpiredException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(new RsData<>("401-1", e.getMessage(), null));
+    }
+
+    @ExceptionHandler(MissingRequestHeaderException.class)
+    public ResponseEntity<RsData<Void>> handleMissingHeader(MissingRequestHeaderException ex) {
+        if ("X-Client-Base-Url".equals(ex.getHeaderName())) {
+            return handleUnihubException(
+                    new UnihubException("400", "X-Client-Base-Url 헤더가 필요합니다.")
+            );
+        }
+
+        return handleUnihubException( new UnihubException("400", ex.getMessage()) );
+    }
+
+    @ExceptionHandler(AsyncRequestNotUsableException.class)
+    public ResponseEntity<RsData<Void>> handleAsyncNotUsable(AsyncRequestNotUsableException e) {
+        return ResponseEntity
+                .status(HttpStatus.SERVICE_UNAVAILABLE)
+                .body(new RsData<>("503", "서비스를 일시적으로 사용할 수 없습니다.", null));
+    }
 }

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/init/InitProdOrStgData.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/init/InitProdOrStgData.java
@@ -119,44 +119,40 @@ public class InitProdOrStgData {
     private List<Course> initCoursesForSw(Professor professor, Major major) {
 
         // 자료구조
-        String url1 = uploadCourseImageToS3("static/Syllabus_example.png");
         Course dataStructure = helper.createCourse(
                 "자료구조", major, "교육관 401호",
                 30, 0, 3,
                 professor,
-                3, 2, url1
+                3, 2, "/plans/data-structure.pdf"
         );
         helper.createCourseScheduleAndAssociateWithCourse(dataStructure, DayOfWeek.MON, "09:00:00", "10:30:00");
         helper.createCourseScheduleAndAssociateWithCourse(dataStructure, DayOfWeek.FRI, "14:00:00", "15:30:00");
 
         // 운영체제
-        String url2 = uploadCourseImageToS3("static/Syllabus_example.png");
         Course os = helper.createCourse(
                 "운영체제", major, "교육관 402호",
                 30, 0, 2,
                 professor,
-                3, 2, url2
+                3, 2, "/plans/os.pdf"
         );
         helper.createCourseScheduleAndAssociateWithCourse(os, DayOfWeek.TUE, "09:00:00", "10:30:00");
         helper.createCourseScheduleAndAssociateWithCourse(os, DayOfWeek.THU, "14:00:00", "15:30:00");
 
         // 네트워크
-        String url3 = uploadCourseImageToS3("static/Syllabus_example.png");
         Course network = helper.createCourse(
                 "네트워크", major, "교육관 403호",
                 25, 0, 3,
                 professor,
-                3, 2, url3
+                3, 2, "/plans/network.pdf"
         );
         helper.createCourseScheduleAndAssociateWithCourse(network, DayOfWeek.WED, "10:00:00", "11:30:00");
         helper.createCourseScheduleAndAssociateWithCourse(network, DayOfWeek.FRI, "16:00:00", "17:30:00");
 
-        String url4 = uploadCourseImageToS3("static/Syllabus_example.png");
         Course javaCourse = helper.createCourse(
                 "자바 프로그래밍", major, "교육관 301호",
                 40, 0, 3,
                 professor,
-                1, 1, url4
+                1, 1, "/plans/java.pdf"
         );
         helper.createCourseScheduleAndAssociateWithCourse(javaCourse, DayOfWeek.MON, "09:00", "11:00");
 
@@ -167,30 +163,26 @@ public class InitProdOrStgData {
      * 컴퓨터공학전공 강좌 생성 메서드
      */
     private List<Course> initCoursesForCS(Professor professor, Major major) {
-
-        String url1 = uploadCourseImageToS3("static/Syllabus_example.png");
         Course algo = helper.createCourse(
                 "알고리즘", major, "공학관 201호",
                 30, 0, 3, professor,
-                2, 1, url1
+                2, 1, "/plans/algorithm.pdf"
         );
         helper.createCourseScheduleAndAssociateWithCourse(algo, DayOfWeek.MON, "10:00:00", "11:30:00");
         helper.createCourseScheduleAndAssociateWithCourse(algo, DayOfWeek.WED, "13:00:00", "14:30:00");
 
-        String url2 = uploadCourseImageToS3("static/Syllabus_example.png");
         Course db = helper.createCourse(
                 "데이터베이스", major, "공학관 202호",
                 35, 0, 3, professor,
-                2, 1, url2
+                2, 1, "/plans/database.pdf"
         );
         helper.createCourseScheduleAndAssociateWithCourse(db, DayOfWeek.TUE, "09:00:00", "10:30:00");
         helper.createCourseScheduleAndAssociateWithCourse(db, DayOfWeek.THU, "14:00:00", "15:30:00");
 
-        String url3 = uploadCourseImageToS3("static/Syllabus_example.png");
         Course ai = helper.createCourse(
                 "인공지능", major, "공학관 203호",
                 25, 0, 3, professor,
-                2, 1, url3
+                2, 1, "/plans/ai.pdf"
         );
         helper.createCourseScheduleAndAssociateWithCourse(ai, DayOfWeek.FRI, "11:00:00", "12:30:00");
 
@@ -199,37 +191,34 @@ public class InitProdOrStgData {
 
     private void initConflictCourses(Professor professor, Major major) {
         // 1) 정원초과 강좌 (capacity=30, 이미 enrolled=30 신청함)
-        String url1 = uploadCourseImageToS3("static/Syllabus_example.png");
         Course full = helper.createCourse(
                 "정원초과강좌", major, "OO동 104호",
                 30, 30,
                 3,                          // credit
                 professor,
-                1, 1, url1
+                1, 1, "/plans/full.pdf"
         );
         helper.createCourseScheduleAndAssociateWithCourse(
                 full, DayOfWeek.FRI, "09:00:00", "10:00:00"
         );
 
         // 2) 학점초과 강좌 (21학점짜리, 신청 시 반드시 초과)
-        String url2 = uploadCourseImageToS3("static/Syllabus_example.png");
         Course heavy = helper.createCourse(
                 "학점초과강좌", major, "OO동 105호",
                 30, 0,                      // capacity=30, enrolled=0
                 21,                         // credit=20
                 professor,
-                1, 1, url2
+                1, 1, "/plans/heavy.pdf"
         );
         helper.createCourseScheduleAndAssociateWithCourse(
                 heavy, DayOfWeek.THU, "13:00:00", "15:00:00"
         );
         // 3) 시간표충돌 강좌 (모든 요일, 하루종일 스케줄)
-        String url3 = uploadCourseImageToS3("static/Syllabus_example.png");
         Course conflict = helper.createCourse(
                 "충돌강좌", major, "OO동 106호",
                 30, 0, 3,
                 professor,
-                1, 1, url3
+                1, 1, "/plans/conflict.pdf"
         );
         // 모든 DayOfWeek 에 00:00~23:59 스케줄 추가
         for (DayOfWeek day : DayOfWeek.values()) {
@@ -267,25 +256,5 @@ public class InitProdOrStgData {
                 "여름학기 수강신청이 시작됩니다.",
                 summerUrl
         );
-    }
-
-    private String uploadCourseImageToS3(String filePath) {
-        String url;
-
-        try {
-            ClassPathResource resource = new ClassPathResource(filePath);
-            MultipartFile file = new MockMultipartFile(
-                    "file",
-                    resource.getFilename(),
-                    MediaType.IMAGE_PNG_VALUE,
-                    resource.getInputStream()
-            );
-            // S3에 업로드하고 URL 받기
-            url = s3Service.upload(file);
-        } catch (IOException e) {
-            log.error("테스트용 공지사항 이미지 업로드 중 오류 발생", e);
-            throw new UnihubException("500", "테스트 데이터용 공지사항 이미지 업로드 실패");
-        }
-        return url;
     }
 }

--- a/backend/src/test/java/com/WEB4_5_GPT_BE/unihub/domain/timetable/controller/TimetableControllerTest.java
+++ b/backend/src/test/java/com/WEB4_5_GPT_BE/unihub/domain/timetable/controller/TimetableControllerTest.java
@@ -27,10 +27,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
-@Transactional
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
 @RedisTestContainerConfig
+@Transactional
 class TimetableControllerTest {
 
     @Autowired private MockMvc mockMvc;
@@ -257,5 +257,56 @@ class TimetableControllerTest {
                 .andExpect(jsonPath("$.code").value("200"))
                 .andExpect(jsonPath("$.message").value("공유된 시간표 조회 성공"))
                 .andExpect(jsonPath("$.data.timetableId").value(timetableId));
+    }
+
+
+    @Test
+    @DisplayName("시간표에 강의 등록 - 성공")
+    void addCourseItem_success() throws Exception {
+        // 테스트 설정 - 더미 데이터 사용
+
+        // 1. 더미 시간표 ID 생성
+        long timetableId = 1L;
+
+        // 2. 강의 항목 생성 요청 준비
+        String requestJson = "{" +
+                "\"timetableId\": " + timetableId + "," +
+                "\"courseId\": 1," +
+                "\"color\": \"#EA4335\"," +
+                "\"memo\": \"중간고사 5/10\"" +
+                "}";
+
+        // 3. 요청 실행
+        mockMvc.perform(post("/api/timetables/course")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .content(requestJson))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.code").value("201"))
+                .andExpect(jsonPath("$.message").value("강의가 시간표에 성공적으로 등록되었습니다."));
+    }
+
+    @Test
+    @DisplayName("내 강의 목록으로 시간표 일괄 등록 - 성공")
+    void bulkRegisterFromEnrollment_success() throws Exception {
+        // 테스트 설정 - 더미 데이터 사용
+
+        // 1. 더미 시간표 ID 생성
+        long timetableId = 1L;
+
+        // 2. 일괄 등록 요청 준비
+        String requestJson = "{" +
+                "\"timetableId\": " + timetableId + "," +
+                "\"courseIds\": [1, 2, 3]" +
+                "}";
+
+        // 3. 요청 실행
+        mockMvc.perform(post("/api/timetables/bulk")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .content(requestJson))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.code").value("201"))
+                .andExpect(jsonPath("$.message").value("시간표에 반영되었습니다."));
     }
 }

--- a/backend/src/test/java/com/WEB4_5_GPT_BE/unihub/domain/timetable/service/TimetableItemServiceImplTest.java
+++ b/backend/src/test/java/com/WEB4_5_GPT_BE/unihub/domain/timetable/service/TimetableItemServiceImplTest.java
@@ -1,0 +1,382 @@
+package com.WEB4_5_GPT_BE.unihub.domain.timetable.service;
+
+import com.WEB4_5_GPT_BE.unihub.domain.common.enums.DayOfWeek;
+import com.WEB4_5_GPT_BE.unihub.domain.common.enums.TimetableItemType;
+import com.WEB4_5_GPT_BE.unihub.domain.course.entity.Course;
+import com.WEB4_5_GPT_BE.unihub.domain.course.repository.CourseRepository;
+import com.WEB4_5_GPT_BE.unihub.domain.enrollment.repository.EnrollmentRepository;
+import com.WEB4_5_GPT_BE.unihub.domain.member.entity.Professor;
+import com.WEB4_5_GPT_BE.unihub.domain.member.entity.Student;
+import com.WEB4_5_GPT_BE.unihub.domain.timetable.dto.request.item.TimetableCourseAddRequest;
+import com.WEB4_5_GPT_BE.unihub.domain.timetable.dto.request.item.TimetableItemNormalCreateRequest;
+import com.WEB4_5_GPT_BE.unihub.domain.timetable.dto.response.item.TimetableItemDetailResponse;
+import com.WEB4_5_GPT_BE.unihub.domain.timetable.entity.Timetable;
+import com.WEB4_5_GPT_BE.unihub.domain.timetable.entity.TimetableItem;
+import com.WEB4_5_GPT_BE.unihub.domain.timetable.entity.TimetableItemSchedule;
+import com.WEB4_5_GPT_BE.unihub.domain.timetable.exception.DuplicateCourseItemException;
+import com.WEB4_5_GPT_BE.unihub.domain.timetable.exception.TimetableNotFoundException;
+import com.WEB4_5_GPT_BE.unihub.domain.timetable.exception.TimetableUnauthorizedException;
+import com.WEB4_5_GPT_BE.unihub.domain.timetable.repository.TimetableItemRepository;
+import com.WEB4_5_GPT_BE.unihub.domain.timetable.repository.TimetableRepository;
+import com.WEB4_5_GPT_BE.unihub.domain.university.entity.Major;
+import com.WEB4_5_GPT_BE.unihub.domain.university.entity.University;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TimetableItemServiceImplTest {
+
+    @Mock
+    private TimetableRepository timetableRepository;
+
+    @Mock
+    private TimetableItemRepository timetableItemRepository;
+
+    @Mock
+    private CourseRepository courseRepository;
+
+    @Mock
+    private EnrollmentRepository enrollmentRepository;
+
+    @InjectMocks
+    private TimetableItemServiceImpl timetableItemService;
+
+    // 테스트 도우미 메서드들
+    private Student createStudent(Long id, String name, String email) {
+        return Student.builder()
+                .id(id)
+                .name(name)
+                .email(email)
+                .major(Major.builder().id(1L).name("컴퓨터공학과").build())
+                .university(University.builder().id(1L).name("A대학교").build())
+                .build();
+    }
+
+    private Professor createProfessor() {
+        return Professor.builder()
+                .id(3L)
+                .name("박교수")
+                .build();
+    }
+
+    private Course createCourse(Long id, Professor professor) {
+        Course course = Course.builder()
+                .id(id)
+                .title("알고리즘")
+                .location("공학관 401호")
+                .professor(professor)
+                .semester(1)
+                .capacity(30)
+                .enrolled(10)
+                .credit(3)
+                .grade(3)
+                .major(Major.builder().id(1L).name("컴퓨터공학과").build())
+                .build();
+
+        // BaseTimeEntity의 createdAt 설정을 위한 리플렉션 사용 대신
+        // 테스트 목적으로 직접 필드에 접근할 수 있게 만든 코드를 추가해야 하지만,
+        // 테스트에서는 mock을 사용하므로 필요한 시점에 when 구문으로 처리
+        return course;
+    }
+
+    private TimetableItemNormalCreateRequest createNormalItemRequest(Long timetableId) {
+        List<TimetableItemNormalCreateRequest.ScheduleRequest> schedules = new ArrayList<>();
+        schedules.add(new TimetableItemNormalCreateRequest.ScheduleRequest(
+                DayOfWeek.MON, "09:00", "10:30"
+        ));
+
+        return new TimetableItemNormalCreateRequest(
+                timetableId,
+                "알고리즘 스터디",
+                "홍길동",
+                "#4285F4",
+                "도서관 스터디룸",
+                "알고리즘 문제 풀이 스터디",
+                schedules
+        );
+    }
+
+    private TimetableCourseAddRequest createCourseItemRequest(Long timetableId, Long courseId) {
+        return new TimetableCourseAddRequest(
+                timetableId,
+                courseId,
+                "#EA4335",
+                "중간고사 5/10"
+        );
+    }
+
+    @Test
+    @DisplayName("일반 항목 추가 - 정상 케이스")
+    void givenValidRequest_whenAddCustomItem_thenSavesTimetableItem() {
+        // given
+        Student student = createStudent(1L, "김학생", "student@univ.ac.kr");
+        Long timetableId = 1L;
+        TimetableItemNormalCreateRequest request = createNormalItemRequest(timetableId);
+
+        Timetable timetable = Timetable.builder()
+                .id(timetableId)
+                .member(student)
+                .year(2025)
+                .semester(1)
+                .build();
+
+        when(timetableRepository.findById(timetableId)).thenReturn(Optional.of(timetable));
+        when(timetableItemRepository.save(any(TimetableItem.class)))
+                .thenAnswer(invocation -> {
+                    TimetableItem item = invocation.getArgument(0);
+                    // save 메서드 호출 시 ID 부여 시뮬레이션
+                    // 실제 JPA는 저장 시 ID를 부여함
+                    return TimetableItem.builder()
+                            .id(10L)
+                            .timetable(item.getTimetable())
+                            .type(item.getType())
+                            .title(item.getTitle())
+                            .professorName(item.getProfessorName())
+                            .color(item.getColor())
+                            .location(item.getLocation())
+                            .memo(item.getMemo())
+                            .build();
+                });
+
+        // when
+        timetableItemService.createNormalItem(student, request);
+
+        // then
+        verify(timetableRepository).findById(timetableId);
+
+        ArgumentCaptor<TimetableItem> itemCaptor = ArgumentCaptor.forClass(TimetableItem.class);
+        verify(timetableItemRepository).save(itemCaptor.capture());
+
+        TimetableItem capturedItem = itemCaptor.getValue();
+        assertThat(capturedItem.getTitle()).isEqualTo("알고리즘 스터디");
+        assertThat(capturedItem.getType()).isEqualTo(TimetableItemType.NORMAL);
+        assertThat(capturedItem.getColor()).isEqualTo("#4285F4");
+    }
+
+    @Test
+    @DisplayName("시간표가 존재하지 않을 때 일반 항목 추가 - 예외 발생")
+    void givenNonExistentTimetable_whenAddCustomItem_thenThrowsException() {
+        // given
+        Student student = createStudent(1L, "김학생", "student@univ.ac.kr");
+        Long timetableId = 999L; // 존재하지 않는 ID
+        TimetableItemNormalCreateRequest request = createNormalItemRequest(timetableId);
+
+        when(timetableRepository.findById(timetableId)).thenReturn(Optional.empty());
+
+        // when/then
+        assertThatThrownBy(() -> timetableItemService.createNormalItem(student, request))
+                .isInstanceOf(TimetableNotFoundException.class);
+
+        verify(timetableItemRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 시간표에 항목 추가 - 예외 발생")
+    void givenOtherUsersTimetable_whenAddCustomItem_thenThrowsException() {
+        // given
+        Student currentUser = createStudent(1L, "김학생", "student@univ.ac.kr");
+        Student otherUser = createStudent(2L, "이학생", "other@univ.ac.kr");
+        Long timetableId = 1L;
+        TimetableItemNormalCreateRequest request = createNormalItemRequest(timetableId);
+
+        Timetable timetable = Timetable.builder()
+                .id(timetableId)
+                .member(otherUser) // 다른 사용자의 시간표
+                .year(2025)
+                .semester(1)
+                .build();
+
+        when(timetableRepository.findById(timetableId)).thenReturn(Optional.of(timetable));
+
+        // when/then
+        assertThatThrownBy(() -> timetableItemService.createNormalItem(currentUser, request))
+                .isInstanceOf(TimetableUnauthorizedException.class);
+
+        verify(timetableItemRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("강의 항목 추가 - 정상 케이스")
+    void givenValidRequest_whenAddCourseItem_thenSavesTimetableItem() {
+        // given
+        Student student = createStudent(1L, "김학생", "student@univ.ac.kr");
+        Professor professor = createProfessor();
+        Long timetableId = 1L;
+        Long courseId = 5L;
+
+        Timetable timetable = Timetable.builder()
+                .id(timetableId)
+                .member(student)
+                .year(2025)
+                .semester(1)
+                .build();
+
+        Course course = createCourse(courseId, professor);
+
+        TimetableCourseAddRequest request = createCourseItemRequest(timetableId, courseId);
+
+        when(timetableRepository.findById(timetableId)).thenReturn(Optional.of(timetable));
+        when(courseRepository.findById(courseId)).thenReturn(Optional.of(course));
+        when(timetableItemRepository.findByTimetableIdAndCourse(timetableId, course))
+                .thenReturn(Optional.empty());
+        when(timetableItemRepository.save(any(TimetableItem.class)))
+                .thenAnswer(invocation -> {
+                    TimetableItem item = invocation.getArgument(0);
+                    return TimetableItem.builder()
+                            .id(20L)
+                            .timetable(item.getTimetable())
+                            .course(item.getCourse())
+                            .type(item.getType())
+                            .title(item.getTitle())
+                            .professorName(item.getProfessorName())
+                            .color(item.getColor())
+                            .location(item.getLocation())
+                            .memo(item.getMemo())
+                            .build();
+                });
+
+        // when
+        timetableItemService.addCourseItem(student, request);
+
+        // then
+        verify(timetableRepository).findById(timetableId);
+        verify(courseRepository).findById(courseId);
+        verify(timetableItemRepository).findByTimetableIdAndCourse(timetableId, course);
+
+        ArgumentCaptor<TimetableItem> itemCaptor = ArgumentCaptor.forClass(TimetableItem.class);
+        verify(timetableItemRepository).save(itemCaptor.capture());
+
+        TimetableItem capturedItem = itemCaptor.getValue();
+        assertThat(capturedItem.getType()).isEqualTo(TimetableItemType.COURSE);
+        assertThat(capturedItem.getCourse()).isEqualTo(course);
+        assertThat(capturedItem.getColor()).isEqualTo("#EA4335");
+        assertThat(capturedItem.getMemo()).isEqualTo("중간고사 5/10");
+    }
+
+    @Test
+    @DisplayName("이미 등록된 강의 추가 시도 - 예외 발생")
+    void givenDuplicateCourse_whenAddCourseItem_thenThrowsException() {
+        // given
+        Student student = createStudent(1L, "김학생", "student@univ.ac.kr");
+        Professor professor = createProfessor();
+        Long timetableId = 1L;
+        Long courseId = 5L;
+
+        Timetable timetable = Timetable.builder()
+                .id(timetableId)
+                .member(student)
+                .year(2025)
+                .semester(1)
+                .build();
+
+        Course course = createCourse(courseId, professor);
+        TimetableCourseAddRequest request = createCourseItemRequest(timetableId, courseId);
+
+        // 이미 등록된 강의가 있음을 시뮬레이션
+        TimetableItem existingItem = TimetableItem.builder()
+                .id(20L)
+                .timetable(timetable)
+                .course(course)
+                .type(TimetableItemType.COURSE)
+                .title("알고리즘")
+                .professorName("박교수")
+                .color("#EA4335")
+                .build();
+
+        when(timetableRepository.findById(timetableId)).thenReturn(Optional.of(timetable));
+        when(courseRepository.findById(courseId)).thenReturn(Optional.of(course));
+        when(timetableItemRepository.findByTimetableIdAndCourse(timetableId, course))
+                .thenReturn(Optional.of(existingItem));
+
+        // when/then
+        assertThatThrownBy(() -> timetableItemService.addCourseItem(student, request))
+                .isInstanceOf(DuplicateCourseItemException.class);
+
+        verify(timetableItemRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("항목 단건 조회 - 정상 케이스")
+    void givenValidItemId_whenGetItemDetail_thenReturnsDetail() {
+        // given
+        Student student = createStudent(1L, "김학생", "student@univ.ac.kr");
+        Long timetableId = 1L;
+        Long itemId = 10L;
+
+        Timetable timetable = Timetable.builder()
+                .id(timetableId)
+                .member(student)
+                .year(2025)
+                .semester(1)
+                .build();
+
+        TimetableItem item = mock(TimetableItem.class);
+        when(item.getTimetable()).thenReturn(timetable);
+        when(item.getTitle()).thenReturn("알고리즘 스터디");
+        when(item.getColor()).thenReturn("#4285F4");
+
+        List<TimetableItemSchedule> schedules = new ArrayList<>();
+        schedules.add(TimetableItemSchedule.builder()
+                .id(100L)
+                .timetableItem(item)
+                .day(DayOfWeek.MON)
+                .startTime(LocalTime.of(9, 0))
+                .endTime(LocalTime.of(10, 30))
+                .build());
+
+        // 항목 스케줄 설정
+        when(item.getSchedules()).thenReturn(schedules);
+
+        when(timetableItemRepository.findWithSchedulesById(itemId))
+                .thenReturn(Optional.of(item));
+
+        // when
+        TimetableItemDetailResponse response = timetableItemService.getItemDetail(student, itemId);
+
+        // then
+        assertThat(response.title()).isEqualTo("알고리즘 스터디");
+        assertThat(response.year()).isEqualTo(2025);
+        assertThat(response.semester()).isEqualTo(1);
+        assertThat(response.color()).isEqualTo("#4285F4");
+        assertThat(response.schedule()).hasSize(1);
+        assertThat(response.schedule().get(0).day()).isEqualTo("MON");
+        assertThat(response.schedule().get(0).startTime()).isEqualTo("09:00");
+        assertThat(response.schedule().get(0).endTime()).isEqualTo("10:30");
+    }
+
+
+    @Test
+    @DisplayName("항목 삭제 - 정상 케이스")
+    void givenItemId_whenDeleteItem_thenDeletesItem() {
+        // given
+        Student student = createStudent(1L, "김학생", "student@univ.ac.kr");
+        Long itemId = 10L;
+
+        when(timetableItemRepository.existsByIdAndMemberId(itemId, student.getId())).thenReturn(true);
+
+        // when
+        timetableItemService.deleteItem(student, itemId);
+
+        // then
+        verify(timetableItemRepository).existsByIdAndMemberId(itemId, student.getId());
+        verify(timetableItemRepository).deleteById(itemId);
+    }
+}


### PR DESCRIPTION
* docs: develop 초기 데이터 최신화를 위해 ddl-auto를 create로 수정하여 재배포

* docs: 테스트 서버 초기 데이터 최신화 후 ddl-auto를 다시 update로 변경

* feature: 특정 강의를 제외한 스케줄을 조회할 수 있는 쿼리 메소드 추가

* fix: 강의 수정 시 수정되는 강의의 스케줄을 제외하고 스케줄 검증을 실시하도록 수정

* test: 코드 변경사항 반영

* 강을찬/fix 버그와 api명세서와 다른것 수정 (#90)

* [fix] security user 에서 authentication principal 빠진것 추가

* [fix] api endpoint enrollment 에서 enrollments 로 수정

* [fix] AdminController 에서 전공, 대학교 관련 생성,수정,삭제 api 빠진것들 다시 생성

* [fix] test code 에서도 enrollment 대신 enrollments 쓰도록 수정

* [feat] 관리자 api PreAuthorize 추가해 관리자만 접근 가능하도록 수정 (#95)

* studentprofilereponse,professorprofilereponse에 university_id 추가 (#100)

* 로그인시 refreshToken을 Reponse에서 제거, refreshToken의 저장기간을 1일로 변경 (#104)

* refactor: refreshToken을 cookie로만 응답하게 하고, response에서 refreshToken은 삭제

* refactor: refreshToken을 cookie로만 전달하도록 변경, refreshToken의 저장 기간을 1일 로 변경

* 서준식/feat 106 학년,학기,전공에 대한 필터링 추가 (#107)

* controller 수정

* repository,service 수정

* 테스트코드 수정

* query 수정

* 내 수강신청 기간 조회 개발 및 initdata 코드 정리하여 가독성 개선 (#111)

* fix: service단에서 studentProfile을 직접 조회하여 트랜잭션이 종료되어 university 등 값을 불러오지 못하는 lazy 문제 해결

* feat : init data 코드 구조 개선

- 항목별로 분리하여 가독성 향상

* feat : 수강신청 기간 조회 api 개발

* teat: 수강신청 기간 조회 단위 테스트 진행

* test: 수강신청 기간 조회 컨트롤러 테스트 진행

* docs: Swagger 문서 내용 수정

* swagger 문서 최신화 (#112)

* 로그를 sentry에서 검토할 수 있도록 추가 및 특정 에러 발생시 slack에 발송하도록 요청 (#98)

* feat: log 추가 및 에러 상황시 slack에 발송하도록 추가

* test: CourseControllerTest에서 누락된 MockBean 등록 및 context 로딩 오류 수정

* feat: log slack및 centry로그 기능 추가로 인한 환경 변수 및 설정 추가

* chore: CI에서 test를 완료하기 위한 secret,SENTRY_AUTH_TOKEN을 추가(.env파일이 추가가 되지 않으므로)

* chore: 환경설정 파일 CI에서 만들어주는것으로 추가

* chore: env 파일 생성위치 변경

* chore: backend 폴더안에 env 생성하도록 수정

* chore: sentry_토큰 확인용 커밋

* chore: SENTRY AUTH TOKEN 확인작업 제거

* chore: 배포시 환경설정 파일도 배포할 수 있도록 추가

* chore: prod 나 stg일때만 알람을 보내도록 수정

* 서준식/refactor 96 이메일 api 수정 및 로직 변경 (#105)

* 이메일 분리 완료 및 테스트코드 작성

* service, controller test 코드 수정

* 현재 작업상황 저장

* 테스트코드 수정

* 테스트 코드 수정 및  swagger

* docs : Dockerfile에 환경변수 복사 추가

* [REFACTOR] 회원 도메인 재설계 (#116)

* refactor: 회원 엔티티 구조 변경과 그에 따른 관리자 엔티티 추가

* refactor: 회원 엔티티 구조 변경사항 반영

* refactor: 엔티티 클래스 변경사항 반영

* refactor: 초기 데이터 생성에 회원 엔티티 변경사항 반영

* feature: 관리자 엔티티 리포지토리 레이어 추가

* refactor: 회원 엔티티 변경사항 반영

* refactor: 테스트에 회원 엔티티 변경사항 반영

* chore: TODO 주석 추가

* 이메일 로직 변경 (#121)

* docs : stg init data 초기화

* docs : stg init data 초기화 후 ddl update로 다시 수정

* refactor : 기존 rq를 통해 회원정보를 가져오던 방식 제거 (#129)

- Member 도메인이 통합되면서 기존 rq.getActor 메서드를 통해 member의 id만을 가진 객체를 반환할 이유가 사라짐
- 수강신청 관련 메서드에서만 사용중이었기 때문에 getActor, getRealActor 제거
- 인증 방식을 AuthenticationPrincipal 파라메터를 통해 인증하도록 수정

* 옥정현/feat 115 : s3 파일 업로드 및 삭제 기능 구현 & 강의 (등록, 수정, 삭제) 로직에 파일 업로드 기능 추가 (#123)

* feat : s3 파일 업로드 기능 구현 및 테스트용 controller 생성

* refactor : test용 controller 삭제 및 s3Service로 이름 변경 및 위치 이동

- 강의 등록 시 강의계획서 업로드에 사용되기때문에 Course 도메인으로 위치 이동함

* test: s3 service 테스트 코드 추가

* docs : S3Service 설명 주석 추가

* feat : 강의 등록 시 파일 업로드 기능 구현

- 파일 업로드 실패 예외 추가
- 강의 등록 중 예외 발생 시 s3에 업로드했던 파일 삭제
- 기존 json 형식 request에서 form-data 형식으로 변경

* test : 강의등록 테스트 케이스 수정 및 파일 업로드 테스트 추가

* feat : 강의 수정 시 파일 업로드 기능 추가

* test : 강의 수정 테스트 수정 및 파일 업로드 테스트 추가

* feat : 강의 삭제 시 s3에 업로드된 강의계획서가 있다면 삭제하도록 구현

* feat : s3에 업로드된 강의계획서 삭제 실패 시에도 정상적으로 강의가 삭제되도록 try catch 구현

* test : 강의 삭제에 대한 테스트 케이스 추가

* docs : swagger 문서 수정

* refactor : s3 테스트하면서 예외에 추가했던 api 주소 제거 및 중복된 h2-console 주소 제거

* test : s3 업로드된 파일 삭제 로직 테스트 추가

* refactor : 기존 rq를 통해 회원정보를 가져오던 방식 제거 (#129)

- Member 도메인이 통합되면서 기존 rq.getActor 메서드를 통해 member의 id만을 가진 객체를 반환할 이유가 사라짐
- 수강신청 관련 메서드에서만 사용중이었기 때문에 getActor, getRealActor 제거
- 인증 방식을 AuthenticationPrincipal 파라메터를 통해 인증하도록 수정

* feat : s3 파일 업로드 기능 구현 및 테스트용 controller 생성

* refactor : test용 controller 삭제 및 s3Service로 이름 변경 및 위치 이동

- 강의 등록 시 강의계획서 업로드에 사용되기때문에 Course 도메인으로 위치 이동함

* test: s3 service 테스트 코드 추가

* docs : S3Service 설명 주석 추가

* feat : 강의 등록 시 파일 업로드 기능 구현

- 파일 업로드 실패 예외 추가
- 강의 등록 중 예외 발생 시 s3에 업로드했던 파일 삭제
- 기존 json 형식 request에서 form-data 형식으로 변경

* test : 강의등록 테스트 케이스 수정 및 파일 업로드 테스트 추가

* feat : 강의 수정 시 파일 업로드 기능 추가

* test : 강의 수정 테스트 수정 및 파일 업로드 테스트 추가

* feat : 강의 삭제 시 s3에 업로드된 강의계획서가 있다면 삭제하도록 구현

* feat : s3에 업로드된 강의계획서 삭제 실패 시에도 정상적으로 강의가 삭제되도록 try catch 구현

* test : 강의 삭제에 대한 테스트 케이스 추가

* docs : swagger 문서 수정

* refactor : s3 테스트하면서 예외에 추가했던 api 주소 제거 및 중복된 h2-console 주소 제거

* test : s3 업로드된 파일 삭제 로직 테스트 추가

* 서준식/feat 119 공지사항 (#128)

* entity, repository 추가

* dto 생성

* controller ,service 1차 생성

* controller,service 수정

* 테스트코드 작성 및 로직 수정

* 관리자 api 추가 및 dto,service 코드 작성 (#131)

* 강을찬/feat 126 강의에서 추가된 시간표 api 반영 (#134)

* [feat] 시간표 등록용 내 수강 목록 조회

* [chore] swagger operation 멘트 수정

* [feat] 예외 처리 추가

* [feat] api/courses 에서 TIMETABLE mode 추가

* [chore] formatting

* [fix] merge 해결 후 변경사항 반영

rq.getActor -> SecurityUser

* 시간표 기능 도메인 (entity, dto)추가, Service, Controller 템플릿 추가 (#135)

* feat: 공개여부 enum 추가

* feat: 시간표 관련 entity 추가

* feat: 시간표 관련 dto 추가

* feat: 시간표 관련 service 인터페이스 추가

* feat: entity builder, getter, setter등의 annotation 추가

* feat: controller 추가

* feat: 예외처리 추가

* feat: 시간표, 시간표 항목 테스트 추가

* feat: repository 추가

* test: timetableServiceImp 의 테스트 추가

* fix: 8.11.1버전 변경으로 경고창 나타나지 않도록 수정

* feat: rq의 getActor 롤백

* feat: timetable Builder를 사용가능 하도록 변경

* json과 file을 함께 request로 받게될 경우 Content-Type을 직접 application/json으로 명시해줘야 하는 문제 해결 (#138)

* feat: multipart/form-data로 JSON과 파일 Request를 함께 받으면서 JSON 값을 제대로 읽어오지 못하는 문제 해결

- `MultipartJackson2HttpMessageConverter` 추가 – `application/octet-stream` 으로 전송된 JSON 파트도 Jackson으로 자동 파싱 해줌
- `@RequestPart("data")` 바인딩 시 Content-Type 지정 없이도 `CourseRequest` 정상 매핑
- 결과적으로 Postman/Swagger 테스트 시 별도 JSON Content-Type 설정 불필요

* feat: CourseController에 Bearer Auth 로그인 인증을 위한 SecurityRequirement 추가

* 시간표 entity 및 dto 변경 (#140)

* feat: timetable 컬럼 추가 및 schedules 로 변경 컬럼

* feat : repository 추가

* feat: 예외처리 추가

* feat: of 기능 추가

* feat : SeuurityRequire 을 전체 추가

* feat:     @Builder.Default 추가

* 서준식/refactor 136 공지사항 (#142)

* entity, repository 추가

* dto 생성

* controller ,service 1차 생성

* controller,service 수정

* 테스트코드 작성 및 로직 수정

* s3service를 infra 패키지로 옮김

* testcode 작성'

* 초기데이터 삽입

* URL 관련 빼고 작업상황

* dev,prodorStg에 데이터 추가

* url 포함 초기데이터 추가

* request 수정

* feat: 강의 등록, 수정 시 json 형태의 입력값에서는 강의계획서 url 을 받지 않도록 제거함 (#144)

- 등록된 파일을 기준으로 백에서 업로드 후 url을 발급받기 때문에 front로 부터 url을 받아올 이유가 없음
- 혼동 방지하고자 입력 필드 제거

* [REFACTOR] 강의 도메인 버그픽스 및 리팩토링 (#145)

* feature: 강의 도메인 예외 추가

* feature: 대학 도메인 예외 추가

* feature: 스케줄 생성시 시작/종료 시각 검증 로직 추가

* refactor: DB 쿼리로 스케줄이 겹치는지 판단하는 대신 잠재적으로 겹칠 수 있는 스케줄 목록을 반환하도록 변경

* refactor: 상황별로 적절한 예외를 던지도록 변경, 스케줄 검증 로직 추가

* chore: 주석 정리

* test: 리팩토링 변경사항 반영

* feature: 강의 스케줄 시간 검증 예외 추가

* refactor: 강의 스케줄 시간 오류시 던지는 예외 변경

* test: 스케줄 시각 검증 예외 변경사항 반영

* hotfix 관리자 encode 적용

* 관리자 초대 테스트코드 수정 (#151)

* 옥정현/fix 148 한글명 파일이 s3에 업로드되지 않던 인코딩 문제 해결 (#150)

* fix : 한글 파일 업로드 안되는 문제 해결을 위해 인코딩 로직 추가

- 테스트를 위해 임시로 옥정현/fix-148 push로 테스트 서버에 배포

* feat : 파일 업로드 시 공백을 언더바로 변경해주도록 수정

* feat : 파일 명이 없을경우 unknown으로 저장되도록 로직 추가, activeProfile에 따라 다르게 저장되도록 추가구현

* feat : 인코딩된 이름이 아니라 실제 파일 이름으로 s3에 저장되도록 수정

* docs : 테스트 확인용 push branch 제거

* test : 변경된 로직에 맞게 테스트코드 수정

* fix : 한글 파일 업로드 안되는 문제 해결을 위해 인코딩 로직 추가

- 테스트를 위해 임시로 옥정현/fix-148 push로 테스트 서버에 배포

* feat : 파일 업로드 시 공백을 언더바로 변경해주도록 수정

* feat : 파일 명이 없을경우 unknown으로 저장되도록 로직 추가, activeProfile에 따라 다르게 저장되도록 추가구현

* feat : 인코딩된 이름이 아니라 실제 파일 이름으로 s3에 저장되도록 수정

* docs : 테스트 확인용 push branch 제거

* test : 변경된 로직에 맞게 테스트코드 수정

* fix : 한글 파일 업로드 안되는 문제 해결을 위해 인코딩 로직 추가

- 테스트를 위해 임시로 옥정현/fix-148 push로 테스트 서버에 배포

# Conflicts:
#	backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/infra/s3/S3Service.java

* feat : 파일 업로드 시 공백을 언더바로 변경해주도록 수정

* feat : 파일 명이 없을경우 unknown으로 저장되도록 로직 추가, activeProfile에 따라 다르게 저장되도록 추가구현

* docs : 테스트 확인용 push branch 제거

* 서준식/refactor 147 공지사항 리팩토링 (#149)

* 소프트 삭제된 공지사항 제외하고 조회하도록 인덱스 작성

* 필요없는 dto 삭제

* db 삭제 스케줄러 구현

* 강을찬/bug 152 admin 수강 신청 기간 조회 에러 (#153)

* [fix] lazy init 문제 해결

* [fix] query string 누락 시 400 에러

* [fix] N+1 문제 안나도록 수정

* 시간표 Controller, Service 및 Test 구현 (#146)

* test: testData생성

* feat: timetable 관련 repository 및 entity 수정

* feat: service및 구현체 변경

 - // 등록된 시간표 학기 목록 조회 는 사용되지 않기 때문에 삭제 하였습니다

* test: 기본 테스트 파일 변경

* feat: 예외 처리 추가

* feat : 시간표 controller 구현

* feat : 헤더 예외처리 추가

* test: 시간표 예외처리 구현

* refactor: 사용하지 않는 주석 삭제

* refactor : error메세지 -> 비공개 시간표 본인만 열람가능 으로 변경

* feat: 비공개 라도 자기자신은 열람 가능하도록 수정

* test: 비공개라도 자기가 열람가능하도록 한것 테스트 코드 작성

* Update README.md

* hotfix 성철님 코드 적용 (#159)

* docs : db 초기화 진행

- 강의계획서 이미지 업로드

* docs : db 초기화 후 db update로 재설정

* 강을찬/feat 137 timetable api  (#158)

* [feat] 필요한 exception 추가

* [feat] 필요한 exception 추가

* [feat] global exception 추가

* [feat] request response 추가

* [feat] 시간표 item 관련 api 완성

* [test] test code 작성

* [fix] return type 잘못만든거 수정

* [fix] test code 수정

---------

## ✨ 변경 사항 설명

<!-- 🔍 이 PR에서 변경된 내용을 간략하게 설명해주세요. -->

## ✅ 체크리스트

<!-- 📝 완료된 항목은 [x]로 표시해주세요. -->

- [ ] 🏗️ 코드가 **코딩 스타일 가이드**를 준수합니다.
- [ ] 🧪 변경 사항에 대한 **테스트가 추가**되었습니다.
- [ ] ✅ 모든 **테스트가 정상적으로 통과**합니다.
- [ ] 📚 필요한 **문서가 업데이트**되었습니다.

## 🎨 스크린샷 (UI 변경이 있는 경우)

<!-- 🖼️ 변경 전/후 스크린샷을 추가해주세요. -->

## 🛠️ 테스트 방법 (필요시)

<!-- 🧑‍💻 이 PR을 테스트하는 방법을 설명해주세요. -->
