### PR TITLE
[BUGFIX] 강의 생성시 대학 정보 획득 방식 변경

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -39,5 +39,6 @@ out/
 ### custom ###
 unihub_dev.mv.db
 unihub_dev.trace.db
+unihub_dev.lock.db
 src/main/resources/application-secret.yml
 .env

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -87,6 +87,9 @@ dependencies {
 
     // AWS S3
     implementation("io.awspring.cloud:spring-cloud-aws-starter-s3:3.3.0")
+
+    // Redisson (redis를 통한 분산락)
+    implementation("org.redisson:redisson-spring-boot-starter:3.46.0")
 }
 
 

--- a/backend/k6/30_student_enrollment.js
+++ b/backend/k6/30_student_enrollment.js
@@ -1,0 +1,80 @@
+import http from "k6/http";
+import {check} from "k6";
+import {SharedArray} from "k6/data";
+import {Counter} from "k6/metrics";
+
+// —— 테스트 파라미터 ——
+const VUS = 30;  // 30명의 학생만
+const COURSE_ID = 11;
+const BASE = __ENV.BASE || "http://host.docker.internal:8080";
+
+// students.json 로드 (100개 계정)
+const allUsers = new SharedArray("students", () =>
+    JSON.parse(open("students.json"))
+);
+
+// 앞에서부터 30명만 사용
+const users = allUsers.slice(0, VUS);
+
+// 성공/실패 카운터
+export let enrollSuccess = new Counter("enroll_success");
+export let enrollFail = new Counter("enroll_fail");
+
+export let options = {
+    scenarios: {
+        enrollmentTest: {
+            executor: "per-vu-iterations",
+            vus: VUS,
+            iterations: 1,
+            maxDuration: "30s",
+        },
+    },
+    thresholds: {
+        // 30명 중 30명은 성공, 0명은 실패 기대
+        "enroll_success": ["count == 30"],
+        "enroll_fail": ["count == 0"],
+    },
+};
+
+export default function () {
+    // VU 번호에 맞춰 0..29 인덱스 사용자 선택
+    const user = users[__VU - 1];
+
+    // 1) 로그인
+    let loginRes = http.post(
+        `${BASE}/api/members/login`,
+        JSON.stringify({email: user.email, password: user.password}),
+        {headers: {"Content-Type": "application/json"}}
+    );
+    check(loginRes, {"login 200": r => r.status === 200});
+    if (loginRes.status !== 200) {
+        enrollFail.add(1);
+        return;
+    }
+    const token = loginRes.json("data.accessToken");
+
+    // 2) 비동기 수강신청 요청
+    let res = http.post(
+        `${BASE}/api/enrollments`,
+        JSON.stringify({courseId: COURSE_ID}),
+        {
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${token}`,
+            },
+        }
+    );
+
+    if (res.status >= 200 && res.status < 300) {
+        enrollSuccess.add(1);
+    } else {
+        enrollFail.add(1);
+    }
+}
+
+
+// 실행 방법
+// 1. Docker 환경에서 실행
+// 2. c: 경로에 js 파일과 students.json 파일을 저장
+// 3. 해당 경로로 이동하여 powershell에서 아래 명령어 실행
+// docker run --rm --name k6_1 --network common -v ${pwd}:/scripts -w /scripts grafana/k6:latest run 30_student_enrollment.js

--- a/backend/k6/30_student_enrollmentCancel.js
+++ b/backend/k6/30_student_enrollmentCancel.js
@@ -1,0 +1,78 @@
+import http from "k6/http";
+import {check} from "k6";
+import {SharedArray} from "k6/data";
+import {Counter} from "k6/metrics";
+
+// —— 테스트 파라미터 ——
+const VUS = 30;  // 30명의 학생
+const COURSE_ID = 11;
+const BASE = __ENV.BASE || "http://host.docker.internal:8080";
+
+// students.json 로드 (100개 계정)
+const allUsers = new SharedArray("students", () =>
+    JSON.parse(open("students.json"))
+);
+
+// 앞에서부터 30명만 사용
+const users = allUsers.slice(0, VUS);
+
+// 성공/실패 카운터
+export let cancelSuccess = new Counter("cancel_success");
+export let cancelFail = new Counter("cancel_fail");
+
+export let options = {
+    scenarios: {
+        cancellationTest: {
+            executor: "per-vu-iterations",
+            vus: VUS,
+            iterations: 1,
+            maxDuration: "30s",
+        },
+    },
+    thresholds: {
+        // 30명 중 30건 성공, 0건 실패 기대
+        "cancel_success": ["count == 30"],
+        "cancel_fail": ["count == 0"],
+    },
+};
+
+export default function () {
+    // VU 번호에 맞춰 0..29 인덱스 사용자 선택
+    const user = users[__VU - 1];
+
+    // 1) 로그인
+    let loginRes = http.post(
+        `${BASE}/api/members/login`,
+        JSON.stringify({email: user.email, password: user.password}),
+        {headers: {"Content-Type": "application/json"}}
+    );
+    check(loginRes, {"login 200": r => r.status === 200});
+    if (loginRes.status !== 200) {
+        cancelFail.add(1);
+        return;
+    }
+    const token = loginRes.json("data.accessToken");
+
+    // 2) 수강 취소 요청
+    let res = http.del(
+        `${BASE}/api/enrollments/${COURSE_ID}`,
+        null,
+        {
+            headers: {
+                Authorization: `Bearer ${token}`,
+            },
+        }
+    );
+
+    if (res.status >= 200 && res.status < 300) {
+        cancelSuccess.add(1);
+    } else {
+        cancelFail.add(1);
+    }
+}
+
+// 실행 방법
+// 1. Docker 환경에서 실행
+// 2. c: 경로에 js 파일과 students.json 파일을 저장
+// 3. 해당 경로로 이동하여 powershell에서 아래 명령어 실행
+// docker run --rm --name k6_1 --network common -v ${pwd}:/scripts -w /scripts grafana/k6:latest run 30_student_enrollmentCancel.js

--- a/backend/k6/enroll-cap30-vus100.js
+++ b/backend/k6/enroll-cap30-vus100.js
@@ -1,0 +1,77 @@
+import http from "k6/http";
+import {check} from "k6";
+import {SharedArray} from "k6/data";
+import {Counter} from "k6/metrics";
+
+// —— 테스트 파라미터 ——
+const VUS = 100;
+const COURSE_ID = 11;
+const BASE = __ENV.BASE || "http://host.docker.internal:8080";
+
+// students.json 로드 (100개 계정)
+const users = new SharedArray("students", () =>
+    JSON.parse(open("students.json"))
+);
+
+// 성공/실패 카운터
+export let enrollSuccess = new Counter("enroll_success");
+export let enrollFail = new Counter("enroll_fail");
+
+export let options = {
+    scenarios: {
+        enrollmentTest: {
+            executor: "per-vu-iterations",
+            vus: VUS,
+            iterations: 1,
+            maxDuration: "30s",
+        },
+    },
+    thresholds: {
+        // 30건 2xx 성공, 70건 비2xx 실패
+        "enroll_success": ["count == 30"],
+        "enroll_fail": ["count == 70"],
+    },
+};
+
+export default function () {
+    // 각 VU마다 한 번씩 실행
+    const user = users[(__VU - 1) % users.length];
+
+    // 1) 로그인
+    let loginRes = http.post(
+        `${BASE}/api/members/login`,
+        JSON.stringify({email: user.email, password: user.password}),
+        {headers: {"Content-Type": "application/json"}}
+    );
+    check(loginRes, {"login 200": r => r.status === 200});
+    if (loginRes.status !== 200) {
+        enrollFail.add(1);
+        return;
+    }
+    const token = loginRes.json("data.accessToken");
+
+    // 2) 비동기 수강신청 요청
+    let res = http.post(
+        `${BASE}/api/enrollments`,
+        JSON.stringify({courseId: COURSE_ID}),
+        {
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${token}`,
+            },
+        }
+    );
+
+    if (res.status >= 200 && res.status < 300) {
+        enrollSuccess.add(1);
+    } else {
+        enrollFail.add(1);
+    }
+}
+
+
+// 실행 방법
+// 1. Docker 환경에서 실행
+// 2. c: 경로에 js 파일과 students.json 파일을 저장
+// 3. 해당 경로로 이동하여 powershell에서 아래 명령어 실행
+// docker run --rm --name k6_1 --network common -v ${pwd}:/scripts -w /scripts grafana/k6:latest run enroll-cap30-vus100.js

--- a/backend/k6/enroll-single-student-v5.js
+++ b/backend/k6/enroll-single-student-v5.js
@@ -1,0 +1,74 @@
+import http from "k6/http";
+import {Counter} from "k6/metrics";
+
+// —— 테스트 파라미터 ——
+// 한 학생이 동시에 보낼 요청 수
+const VUS = 5;
+const ITERATIONS = 5;
+const COURSE_ID = 11;
+const BASE = __ENV.BASE || "http://host.docker.internal:8080";
+
+// 테스트할 단일 학생 계정
+const STUDENT = {
+    email: "concurrencyStudent1@auni.ac.kr",
+    password: "studentPw",
+};
+
+// 성공/실패 카운터
+export let enrollSuccess = new Counter("enroll_success");
+export let enrollFail = new Counter("enroll_fail");
+export let loginFail = new Counter("login_fail");
+
+export let options = {
+    scenarios: {
+        singleStudentTest: {
+            executor: "shared-iterations",
+            vus: VUS,              // 동시에 5 VU
+            iterations: ITERATIONS,// 총 5회 반복
+            maxDuration: "10s",
+        },
+    },
+    thresholds: {
+        // 1번만 성공, 4번은 실패를 기대
+        "enroll_success": ["count == 1"],
+        "enroll_fail": ["count == 4"],
+    },
+};
+
+export default function () {
+    // 1) 로그인
+    let loginRes = http.post(
+        `${BASE}/api/members/login`,
+        JSON.stringify(STUDENT),
+        {headers: {"Content-Type": "application/json"}}
+    );
+    if (loginRes.status !== 200 || !loginRes.json("data.accessToken")) {
+        loginFail.add(1);
+        return;
+    }
+    const token = loginRes.json("data.accessToken");
+
+    // 2) 수강신청
+    let enrollRes = http.post(
+        `${BASE}/api/enrollments`,
+        JSON.stringify({courseId: COURSE_ID}),
+        {
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${token}`,
+            },
+        }
+    );
+
+    if (enrollRes.status >= 200 && enrollRes.status < 300) {
+        enrollSuccess.add(1);
+    } else {
+        enrollFail.add(1);
+    }
+}
+
+// 실행 방법
+// 1. Docker 환경에서 실행
+// 2. c: 경로에 js 파일과 students.json 파일을 저장
+// 3. 해당 경로로 이동하여 powershell에서 아래 명령어 실행
+// docker run --rm --name k6_1 --network common -v ${pwd}:/scripts -w /scripts grafana/k6:latest run enroll-single-student-v5.js

--- a/backend/k6/students.json
+++ b/backend/k6/students.json
@@ -1,0 +1,402 @@
+[
+  {
+    "email": "concurrencyStudent1@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent2@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent3@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent4@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent5@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent6@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent7@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent8@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent9@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent10@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent11@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent12@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent13@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent14@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent15@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent16@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent17@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent18@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent19@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent20@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent21@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent22@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent23@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent24@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent25@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent26@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent27@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent28@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent29@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent30@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent31@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent32@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent33@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent34@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent35@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent36@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent37@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent38@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent39@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent40@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent41@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent42@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent43@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent44@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent45@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent46@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent47@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent48@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent49@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent50@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent51@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent52@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent53@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent54@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent55@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent56@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent57@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent58@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent59@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent60@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent61@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent62@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent63@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent64@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent65@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent66@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent67@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent68@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent69@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent70@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent71@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent72@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent73@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent74@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent75@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent76@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent77@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent78@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent79@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent80@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent81@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent82@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent83@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent84@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent85@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent86@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent87@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent88@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent89@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent90@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent91@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent92@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent93@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent94@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent95@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent96@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent97@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent98@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent99@auni.ac.kr",
+    "password": "studentPw"
+  },
+  {
+    "email": "concurrencyStudent100@auni.ac.kr",
+    "password": "studentPw"
+  }
+]

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/course/controller/CourseController.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/course/controller/CourseController.java
@@ -81,9 +81,11 @@ public class CourseController {
             @RequestPart("data") CourseWithOutUrlRequest courseWithOutUrlRequest,
 
             @Parameter(description = "강의계획서 파일", content = @Content(mediaType = "application/octet-stream"))
-            @RequestPart(name = "file", required = false) MultipartFile coursePlanFile
+            @RequestPart(name = "file", required = false) MultipartFile coursePlanFile,
+
+            @AuthenticationPrincipal SecurityUser principal
     ) {
-        CourseWithFullScheduleResponse res = courseService.createCourse(courseWithOutUrlRequest, coursePlanFile);
+        CourseWithFullScheduleResponse res = courseService.createCourse(courseWithOutUrlRequest, coursePlanFile, principal);
         return new RsData<>(String.valueOf(HttpStatus.CREATED.value()), "성공적으로 생성되었습니다.", res);
     }
 
@@ -118,9 +120,11 @@ public class CourseController {
             @RequestPart("data") CourseWithOutUrlRequest courseWithOutUrlRequest,
 
             @Parameter(description = "새로운 강의계획서 파일", content = @Content(mediaType = "application/octet-stream"))
-            @RequestPart(name = "file", required = false) MultipartFile coursePlanFile
+            @RequestPart(name = "file", required = false) MultipartFile coursePlanFile,
+
+            @AuthenticationPrincipal SecurityUser principal
     ) {
-        CourseWithFullScheduleResponse res = courseService.updateCourse(courseId, courseWithOutUrlRequest, coursePlanFile);
+        CourseWithFullScheduleResponse res = courseService.updateCourse(courseId, courseWithOutUrlRequest, coursePlanFile, principal);
         return new RsData<>(String.valueOf(HttpStatus.OK.value()), "성공적으로 수정되었습니다.", res);
     }
 

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/course/dto/CourseRequest.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/course/dto/CourseRequest.java
@@ -15,7 +15,7 @@ public record CourseRequest(
         @Schema(description = "강의 전공")
         @NotEmpty String major,
         @Schema(description = "소속 대학")
-        @NotEmpty String university,
+        String university,
         @Schema(description = "강의장")
         @NotEmpty String location,
         @Schema(description = "수강 정원")

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/course/repository/CourseRepository.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/course/repository/CourseRepository.java
@@ -4,6 +4,7 @@ import com.WEB4_5_GPT_BE.unihub.domain.course.entity.Course;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -41,4 +42,26 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
     );
 
     List<Course> findByProfessorId(Long professorId);
+
+    /**
+     * course.enrolled 컬럼을 1 증가시킵니다.
+     * (동시성 처리를 DB 레벨에서 atomic 하게 해 줍니다.)
+     *
+     * @param courseId 증가시킬 Course의 ID
+     */
+    @Modifying
+    @Query("UPDATE Course c SET c.enrolled = c.enrolled + 1 WHERE c.id = :courseId")
+    void incrementEnrolled(@Param("courseId") Long courseId);
+
+    /**
+     * course.enrolled 컬럼을 1 감소시킵니다.
+     * (동시성 처리를 DB 레벨에서 atomic 하게 해 줍니다.)
+     *
+     * @param courseId 감소시킬 Course의 ID
+     */
+    @Modifying
+    @Query("UPDATE Course c SET c.enrolled = c.enrolled - 1 WHERE c.id = :courseId")
+    void decrementEnrolled(@Param("courseId") Long courseId);
+
+
 }

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/course/service/CourseRedisCounterService.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/course/service/CourseRedisCounterService.java
@@ -1,0 +1,26 @@
+package com.WEB4_5_GPT_BE.unihub.domain.course.service;
+
+import com.WEB4_5_GPT_BE.unihub.domain.course.entity.Course;
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CourseRedisCounterService {
+    private final RedissonClient redisson;
+
+    public void syncCourseCounters(Course course) {
+        String keyCapacity = "course:" + course.getId() + ":capacity";
+        String keyEnrolled = "course:" + course.getId() + ":enrolled";
+        redisson.getAtomicLong(keyCapacity).set(course.getCapacity());
+        redisson.getAtomicLong(keyEnrolled).set(course.getEnrolled());
+    }
+
+    public void deleteCourseCounters(Course course) {
+        String keyCapacity = "course:" + course.getId() + ":capacity";
+        String keyEnrolled = "course:" + course.getId() + ":enrolled";
+        redisson.getAtomicLong(keyCapacity).delete();
+        redisson.getAtomicLong(keyEnrolled).delete();
+    }
+}

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/course/service/CourseService.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/course/service/CourseService.java
@@ -80,8 +80,12 @@ public class CourseService {
      * @param courseRequest 강의 정보
      * @return 생성된 강의의 {@link CourseWithFullScheduleResponse} DTO
      */
-    public CourseWithFullScheduleResponse createCourse(CourseRequest courseRequest) {
-        University u = universityRepository.findByName(courseRequest.university()).orElseThrow(
+    public CourseWithFullScheduleResponse createCourse(CourseRequest courseRequest, SecurityUser principal) {
+//        University u = universityRepository.findByName(courseRequest.university()).orElseThrow(
+//                UniversityNotFoundException::new
+//        );
+        Long universityId = getUnivIdFromPrincipal(principal);
+        University u = universityRepository.findById(universityId).orElseThrow(
                 UniversityNotFoundException::new
         );
         Major m = majorRepository.findByUniversityIdAndName(u.getId(), courseRequest.major()).orElseThrow(
@@ -107,14 +111,14 @@ public class CourseService {
         return CourseWithFullScheduleResponse.from(saved);
     }
 
-    public CourseWithFullScheduleResponse createCourse(CourseWithOutUrlRequest req, MultipartFile file) {
+    public CourseWithFullScheduleResponse createCourse(CourseWithOutUrlRequest req, MultipartFile file, SecurityUser principal) {
         String url = null;
         try {
             if (file != null && !file.isEmpty()) {
                 url = s3Service.upload(file);
             }
             CourseRequest courseRequest = req.withCoursePlanAttachment(url);
-            return createCourse(courseRequest); // 기존 createCourse(CourseRequest) 호출
+            return createCourse(courseRequest, principal); // 기존 createCourse(CourseRequest) 호출
         } catch (IOException e) {
             throw new FileUploadException();
         } catch (UnihubException ex) {
@@ -130,10 +134,14 @@ public class CourseService {
      * @param courseRequest 덮어쓸 정보
      * @return 수정된 강의의 {@link CourseWithFullScheduleResponse} DTO
      */
-    public CourseWithFullScheduleResponse updateCourse(Long courseId, CourseRequest courseRequest) {
+    public CourseWithFullScheduleResponse updateCourse(Long courseId, CourseRequest courseRequest, SecurityUser principal) {
         Course orig = courseRepository.findById(courseId).orElseThrow(
                 CourseNotFoundException::new);
-        University u = universityRepository.findByName(courseRequest.university()).orElseThrow(
+//        University u = universityRepository.findByName(courseRequest.university()).orElseThrow(
+//                UniversityNotFoundException::new
+//        );
+        Long universityId = getUnivIdFromPrincipal(principal);
+        University u = universityRepository.findById(universityId).orElseThrow(
                 UniversityNotFoundException::new
         );
         Major m = majorRepository.findByUniversityIdAndName(u.getId(), courseRequest.major()).orElseThrow(
@@ -167,7 +175,7 @@ public class CourseService {
      * @param file     강의계획서 파일
      * @return 입력한 file을 업로드 및 강의계획서 URL을 업데이트하여 기존 updateCourse(courseId, courseRequest) 호출
      */
-    public CourseWithFullScheduleResponse updateCourse(Long courseId, CourseWithOutUrlRequest req, MultipartFile file) {
+    public CourseWithFullScheduleResponse updateCourse(Long courseId, CourseWithOutUrlRequest req, MultipartFile file, SecurityUser principal) {
 
         // 1) 원본 url 조회
         Course origin = courseRepository.findById(courseId).orElseThrow(CourseNotFoundException::new);
@@ -183,7 +191,7 @@ public class CourseService {
             }
             // 4) 기존 URL이거나, 새로 업로드된 URL을 끼워 넣음
             CourseRequest courseRequest = req.withCoursePlanAttachment(url);
-            return updateCourse(courseId, courseRequest);
+            return updateCourse(courseId, courseRequest, principal);
         } catch (IOException e) {
             throw new FileUploadException();
         } catch (UnihubException ex) {

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/controller/EnrollmentController.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/controller/EnrollmentController.java
@@ -14,6 +14,7 @@ import com.WEB4_5_GPT_BE.unihub.domain.enrollment.springDoc.apiResponse.Enrollme
 import com.WEB4_5_GPT_BE.unihub.domain.enrollment.springDoc.apiResponse.GetMyEnrollmentListApiResponse;
 import com.WEB4_5_GPT_BE.unihub.domain.enrollment.springDoc.apiResponse.getMyEnrollmentPeriodApiResponse;
 import com.WEB4_5_GPT_BE.unihub.domain.member.entity.Student;
+import com.WEB4_5_GPT_BE.unihub.domain.member.exception.mypage.StudentProfileNotFoundException;
 import com.WEB4_5_GPT_BE.unihub.global.response.Empty;
 import com.WEB4_5_GPT_BE.unihub.global.response.RsData;
 import com.WEB4_5_GPT_BE.unihub.global.security.SecurityUser;
@@ -88,6 +89,8 @@ public class EnrollmentController {
      * @throws EnrollmentPeriodNotFoundException 수강신청 기간 정보가 없는 경우
      * @throws EnrollmentPeriodClosedException   수강신청 기간 외 요청인 경우
      * @throws EnrollmentNotFoundException       수강신청 내역이 없는 경우
+     * @throws CannotCancelException             수강취소 요청 시 현재 수강인원이 0보다 작아지는 경우
+     * @throws RequestAlreadyQueuedException     이미 취소 요청이 큐에 등록되어 있는 경우 (중복요청)
      */
     @Operation(
             summary = "수강 취소",
@@ -99,9 +102,7 @@ public class EnrollmentController {
         // 세션 유효성 검증
         validateEnrollmentSession(user);
 
-        Student actor = Student.builder().id(user.getId()).build();
-        enrollmentService.cancelMyEnrollment(actor, courseId); // 해당 강좌에 대한 수강 취소 요청
-
+        enrollmentService.cancelMyEnrollment(user.getId(), courseId); // 해당 강좌에 대한 수강 신청 요청
         return new RsData<>("200", "수강 취소가 완료되었습니다.");
     }
 
@@ -117,6 +118,8 @@ public class EnrollmentController {
      * @throws DuplicateEnrollmentException      동일 강좌 중복 신청 시
      * @throws CreditLimitExceededException      최대 학점 초과 시
      * @throws ScheduleConflictException         기존 신청한 강좌와 시간표가 겹치는 경우
+     * @throws StudentProfileNotFoundException   학생 프로필이 없는 경우
+     * @throws RequestAlreadyQueuedException     이미 수강신청 요청이 큐에 등록된 경우
      */
     @Operation(
             summary = "수강 신청",
@@ -128,9 +131,7 @@ public class EnrollmentController {
         // 세션 유효성 검증
         validateEnrollmentSession(user);
 
-        Student actor = Student.builder().id(user.getId()).build();
-        enrollmentService.enrollment(actor, request.courseId()); // 해당 강좌에 대한 수강 신청 요청
-
+        enrollmentService.enrollment(user.getId(), request.courseId()); // 해당 강좌에 대한 수강 신청 요청
         return new RsData<>("200", "수강 신청이 완료되었습니다.");
     }
 

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/exception/CannotCancelException.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/exception/CannotCancelException.java
@@ -1,0 +1,9 @@
+package com.WEB4_5_GPT_BE.unihub.domain.enrollment.exception;
+
+import com.WEB4_5_GPT_BE.unihub.global.exception.UnihubException;
+
+public class CannotCancelException extends UnihubException {
+    public CannotCancelException() {
+        super("400", "정원이 0 이하로 내려갈 수 없습니다.");
+    }
+}

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/exception/RequestAlreadyQueuedException.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/exception/RequestAlreadyQueuedException.java
@@ -1,0 +1,12 @@
+package com.WEB4_5_GPT_BE.unihub.domain.enrollment.exception;
+
+import com.WEB4_5_GPT_BE.unihub.global.exception.UnihubException;
+
+/**
+ * 동일 강좌를 중복 신청(따닥)하는 경우 반환하는 예외입니다.
+ */
+public class RequestAlreadyQueuedException extends UnihubException {
+    public RequestAlreadyQueuedException() {
+        super("409", "이미 요청을 처리중입니다.");
+    }
+}

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/repository/EnrollmentRepository.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/repository/EnrollmentRepository.java
@@ -35,6 +35,15 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
      * @return true: 존재, false: 존재하지 않음
      */
     boolean existsByCourseIdAndStudentId(Long courseId, Long studentId);
+
+    /**
+     * 특정 강좌(courseId)에 등록된 모든 수강신청(Enrollment) 내역을 조회합니다.
+     *
+     * @param courseId 수강신청 내역을 가져올 강좌 ID
+     * @return 해당 강좌에 등록된 모든 Enrollment(수강신청) 리스트
+     */
+    List<Enrollment> findAllByCourseId(Long courseId);
+
     /**
      * 특정 강의에 수강신청이 하나라도 존재하는지 확인합니다.
      */

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/service/EnrollmentQueueService.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/service/EnrollmentQueueService.java
@@ -1,15 +1,15 @@
 package com.WEB4_5_GPT_BE.unihub.domain.enrollment.service;
 
-import com.WEB4_5_GPT_BE.unihub.domain.enrollment.dto.QueueStatusDto;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.time.Duration;
+import java.util.List;
+
 import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
-
-import java.time.Duration;
-import java.util.List;
+import com.WEB4_5_GPT_BE.unihub.domain.enrollment.dto.QueueStatusDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Service
@@ -193,7 +193,7 @@ public class EnrollmentQueueService {
     /**
      * 현재 활성 사용자 수 계산 (Redis SCAN 명령어 사용)
      */
-    private Long getActiveUserCount() {
+    protected Long getActiveUserCount() {
         long count = 0;
         ScanOptions options = ScanOptions.scanOptions().match(SESSION_PREFIX + "*").build();
 

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/service/EnrollmentService.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/service/EnrollmentService.java
@@ -12,6 +12,10 @@ import com.WEB4_5_GPT_BE.unihub.domain.enrollment.dto.response.StudentEnrollment
 import com.WEB4_5_GPT_BE.unihub.domain.enrollment.entity.Enrollment;
 import com.WEB4_5_GPT_BE.unihub.domain.enrollment.exception.*;
 import com.WEB4_5_GPT_BE.unihub.domain.enrollment.repository.EnrollmentRepository;
+import com.WEB4_5_GPT_BE.unihub.domain.enrollment.service.async.cancel.EnrollmentCancelCommand;
+import com.WEB4_5_GPT_BE.unihub.domain.enrollment.service.async.cancel.EnrollmentCancelDuplicateChecker;
+import com.WEB4_5_GPT_BE.unihub.domain.enrollment.service.async.enroll.EnrollmentCommand;
+import com.WEB4_5_GPT_BE.unihub.domain.enrollment.service.async.enroll.EnrollmentDuplicateChecker;
 import com.WEB4_5_GPT_BE.unihub.domain.member.entity.Member;
 import com.WEB4_5_GPT_BE.unihub.domain.member.entity.Student;
 import com.WEB4_5_GPT_BE.unihub.domain.member.exception.mypage.StudentProfileNotFoundException;
@@ -19,6 +23,10 @@ import com.WEB4_5_GPT_BE.unihub.domain.member.repository.StudentRepository;
 import com.WEB4_5_GPT_BE.unihub.domain.university.entity.University;
 import com.WEB4_5_GPT_BE.unihub.global.security.SecurityUser;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RAtomicLong;
+import org.redisson.api.RBlockingQueue;
+import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,6 +39,7 @@ import java.util.Optional;
  * 비즈니스 로직을 처리하는 서비스입니다.
  */
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class EnrollmentService {
 
@@ -38,7 +47,15 @@ public class EnrollmentService {
     private final EnrollmentPeriodRepository enrollmentPeriodRepository; // 수강신청 기간 Repository
     private final StudentRepository studentRepository;
     private final CourseRepository courseRepository; // 강좌 Repository
+
+    private final RedissonClient redisson; // 동시성 처리를 위한 RedissonClient
+    private final EnrollmentDuplicateChecker enrollmentCancelDuplicateCheckerDuplicateChecker; // 중복 큐 삽입 방지
+
+    private final RBlockingQueue<EnrollmentCommand> enrollQueue; // 수강신청 요청을 저장하는 Queue
+    private final RBlockingQueue<EnrollmentCancelCommand> cancelQueue; // 수강신청 취소 요청을 저장하는 Queue
+
     private final int MAXIMUM_CREDIT = 21; // 최대 학점 상수 (21학점)
+    private final EnrollmentCancelDuplicateChecker enrollmentCancelDuplicateChecker;
 
     /**
      * 학생의 수강신청 내역을 조회하는 메서드입니다.
@@ -46,7 +63,7 @@ public class EnrollmentService {
      * @param student 로그인 인증된 학생 정보
      * @return 수강신청 내역에 해당하는 {@link MyEnrollmentResponse} DTO 리스트
      */
-    @Transactional
+    @Transactional(readOnly = true)
     public List<MyEnrollmentResponse> getMyEnrollmentList(Member student) {
 
         // student → StudentProfile
@@ -87,35 +104,78 @@ public class EnrollmentService {
     /**
      * 수강 취소 요청을 처리하는 메서드입니다.
      *
-     * @param student  로그인 인증된 학생 정보
+     * @param studentId  로그인 인증된 학생 정보
      * @param courseId 취소할 강좌의 ID
      * @throws EnrollmentPeriodNotFoundException 수강신청 기간 정보가 없는 경우
      * @throws EnrollmentPeriodClosedException   수강신청 기간 외 요청인 경우
      * @throws EnrollmentNotFoundException       수강신청 내역이 없는 경우
      */
-    @Transactional
-    public void cancelMyEnrollment(Member student, Long courseId) {
+    @Transactional(readOnly = true)
+    public void cancelMyEnrollment(Long studentId, Long courseId) {
 
         // Member → StudentProfile 조회
-        Student profile = studentRepository.findById(student.getId())
+        Student profile = studentRepository.findById(studentId)
                 .orElseThrow(StudentProfileNotFoundException::new);
 
         // 수강 취소 가능 기간인지 검증
         ensureEnrollmentPeriodActive(profile);
 
-        // 취소하려는 강좌에 대한 수강 신청 정보 조회
-        Enrollment enrollment = findEnrollment(profile.getId(), courseId);
+        // 수강 신청 내역이 있는지 조회 없다면 예외처리
+        if (!enrollmentRepository.existsByCourseIdAndStudentId(courseId, studentId)) {
+            throw new EnrollmentNotFoundException();
+        }
 
-        // 수강 취소 완료
-        enrollmentRepository.delete(enrollment);
+        // 2) 중복 취소 커맨드 방지
+        enrollmentCancelDuplicateChecker.markEnqueuedIfAbsent(studentId, courseId);
 
-        // 수강 취소 후 해당 강좌의 현재 수강인원 감소
-        decrementEnrolled(enrollment.getCourse());
+        // 3) 실제 취소 자리 공석 + 큐에 커맨드 추가
+        tryDecrementAndEnqueueCancel(studentId, courseId);
+    }
+
+    /**
+     * Redis 큐에 수강취소 명령(EnrollmentCancelCommand)을 추가하여 순차적으로 수강취소 처리합니다.
+     * <p>
+     * 1) AtomicLong을 사용해 현재 수강인원(enrolled)을 1 감소시킵니다.
+     * 2) 감소된 값이 0보다 작으면, 감소를 원복하고 플래그를 삭제한 뒤
+     * CannotCancelException을 던집니다.
+     * 3) 수강취소 명령을 Redis 큐에 enqueue하고,
+     * 실패하는 경우 역시 감소된 카운터와 플래그를 원복합니다.
+     *
+     * @param studentId 학생 ID
+     * @param courseId  강좌 ID
+     * @throws CannotCancelException 취소 가능한 수강신청 내역이 없을 때 발생
+     */
+    private void tryDecrementAndEnqueueCancel(Long studentId, Long courseId) {
+        // Redis 수강인원 카운터 키: course:{courseId}:enrolled
+        String enrolledKey = "course:" + courseId + ":enrolled";
+        RAtomicLong enrolled = redisson.getAtomicLong(enrolledKey);
+
+        // 중복 enqueue 방지 플래그 키: cancel:queued:{studentId}:{courseId}
+        String flagKey = "cancel:queued:" + studentId + ":" + courseId;
+
+        // 1) 수강가능인원 반납 시도: enrolled 값을 1 감소
+        long newCount = enrolled.decrementAndGet();
+        if (newCount < 0) {
+            // 2) 감소된 값이 음수이면 반납 복구 및 플래그 롤백 후 예외 발생
+            enrolled.incrementAndGet();
+            redisson.getBucket(flagKey).delete();
+            throw new CannotCancelException();
+        }
+
+        try {
+            // 3) Redis 큐에 수강취소 명령 추가
+            cancelQueue.add(new EnrollmentCancelCommand(studentId, courseId));
+        } catch (Exception ex) {
+            // 4) enqueue 실패 시 자리 반납 롤백 및 플래그 롤백
+            enrolled.incrementAndGet();
+            redisson.getBucket(flagKey).delete();
+            throw ex;
+        }
     }
 
     /**
      * 수강신청, 취소 가능 기간인지 검증한다.
-     * <p>
+     *
      * 1) 해당 학생의 (학교·연도·학년·학기) 수강신청 기간을 조회하고,
      * 2) 그 기간에 오늘이 포함되는지 검증한다.
      *
@@ -171,46 +231,15 @@ public class EnrollmentService {
     }
 
     /**
-     * 학생 프로필 ID와 강좌 ID로 수강신청 내역을 조회한다.
+     * 비동기 수강 신청을 처리하는 메서드입니다.
      *
-     * @param studentProfileId 학생 프로필의 ID
-     * @param courseId         강좌의 ID
-     * @return 조회된 Enrollment 엔티티
-     * @throws EnrollmentNotFoundException 해당 강좌에 대한 수강신청 내역이 없는 경우
-     */
-    private Enrollment findEnrollment(Long studentProfileId, Long courseId) {
-        return enrollmentRepository
-                .findByCourseIdAndStudentId(courseId, studentProfileId)
-                .orElseThrow(EnrollmentNotFoundException::new);
-    }
-
-    /**
-     * 수강 취소 후 해당 강좌의 현재 수강인원을 감소시킵니다.
-     *
-     * @param course 수강 취소된 강좌
-     */
-    private void decrementEnrolled(Course course) {
-        course.decrementEnrolled();
-        courseRepository.save(course);
-    }
-
-    /**
-     * 수강 신청 후 해당 강좌의 현재 수강인원을 증가시킵니다.
-     *
-     * @param course 수강 취소된 강좌
-     */
-    private void incrementEnrolled(Course course) {
-        course.incrementEnrolled();
-        courseRepository.save(course);
-    }
-
-    /**
-     * 수강 신청을 처리하는 메서드입니다.
      * 여러 예외 상황을 검증한 후 수강 신청을 진행합니다.
-     * 수강 신청 완료 후 해당 강좌의 현재 수강인원을 증가시킵니다.
+     * redis의 AtomicLong을 사용하여 수강인원 카운트를 관리하며 원자성을 보장합니다.
+     * 실제 DB 저장에 저장하는 로직은 redisson queue를 통해 순차적으로 처리합니다.
+     * DB 저장은 별도의 트랜잭션으로 처리하고 사용자의 요청을 redis의 AtomicLong을 통해 바로바로 처리하기 때문에 빠른 응답을 보장합니다.
      *
-     * @param student  로그인 인증된 학생 정보
-     * @param courseId 신청할 강좌의 ID
+     * @param studentId 로그인 인증된 학생 ID
+     * @param courseId  신청할 강좌의 ID
      * @throws CourseNotFoundException           강좌 정보가 없는 경우
      * @throws EnrollmentPeriodNotFoundException 수강신청 기간 정보가 없는 경우
      * @throws EnrollmentPeriodClosedException   수강신청 기간 외 요청인 경우
@@ -219,37 +248,34 @@ public class EnrollmentService {
      * @throws CreditLimitExceededException      최대 학점 초과 시
      * @throws ScheduleConflictException         기존 신청한 강좌와 시간표가 겹치는 경우
      */
-    @Transactional
-    public void enrollment(Member student, Long courseId) {
-        // Member → StudentProfile 추출
-        Student profile = studentRepository.findById(student.getId())
-                .orElseThrow(StudentProfileNotFoundException::new);
+    @Transactional(readOnly = true)
+    public void enrollment(Long studentId, Long courseId) {
 
-        // 수강 신청 가능 기간인지 검증
-        ensureEnrollmentPeriodActive(profile);
-
-        // 신청하려는 강좌 정보 조회
         Course course = courseRepository.findById(courseId)
                 .orElseThrow(CourseNotFoundException::new);
 
+        ensureCapacityAvailable(courseId); // 정원 초과 시 예외 처리
+
+        // Member → StudentProfile 추출
+        Student profile = studentRepository.findById(studentId)
+                .orElseThrow(StudentProfileNotFoundException::new);
+
         ensureEnrollmentAllowed(profile, course); // 수강 신청이 가능한지 여러 예외상황 검증
 
-        // 수강 신청 정보 생성 및 저장
-        Enrollment enrollment = Enrollment.builder()
-                .student(profile)
-                .course(course)
-                .build();
-        enrollmentRepository.save(enrollment);
+        // 2) 동일학생+동일강좌 수강신청이 이미 큐에 들어가있는지 확인
+        enrollmentCancelDuplicateCheckerDuplicateChecker.markEnqueuedIfAbsent(studentId, courseId);
 
-        // 수강 신청 후 해당 강좌의 현재 수강인원 증가
-        incrementEnrolled(enrollment.getCourse());
+        // 3) 실제 자리 확보 + 큐 등록
+        tryReserveSeatAndEnqueue(studentId, courseId);
+
     }
 
     /**
      * 수강 신청이 가능한지 여러 예외 상황을 검증합니다.
      */
     private void ensureEnrollmentAllowed(Student profile, Course course) {
-        ensureCapacityAvailable(course); // 정원 초과 시 예외 처리
+        ensureEnrollmentPeriodActive(profile); // 수강 신청 가능 기간인지 검증
+
         ensureNotAlreadyEnrolled(profile, course); // 동일강좌 중복 신청 방지
 
         List<Enrollment> enrollmentList = enrollmentRepository.findAllByStudent(profile); // 학생 기존 수강 신청 내역
@@ -259,15 +285,58 @@ public class EnrollmentService {
     }
 
     /**
-     * 강좌의 남은 좌석이 1개 이상인지 확인한다.
+     * Redis 카운터를 가져와 남은 자리가 강좌의 남은 좌석이 1개 이상인지 확인한다.
      *
-     * @throws CourseCapacityExceededException 좌석이 없으면
+     * @param courseId 강의 ID
+     * @throws CourseCapacityExceededException 정원 초과 시
      */
-    private void ensureCapacityAvailable(Course course) {
-        if (course.getAvailableSeats() <= 0) {
+    private void ensureCapacityAvailable(Long courseId) {
+
+        long capacity = redisson.getAtomicLong("course:" + courseId + ":capacity").get();   // 전체 정원
+        long enrolled = redisson.getAtomicLong("course:" + courseId + ":enrolled").get();   // 현재까지 예약된 수
+
+        if (enrolled >= capacity) {
             throw new CourseCapacityExceededException();
         }
     }
+
+    /**
+     * Redis의 AtomicLong을 통해 수강신청 자리 확보 후 Redis 큐에 수강신청 명령을 추가합니다.
+     *
+     * @param studentId 학생 ID
+     * @param courseId  강좌 ID
+     * @throws CourseCapacityExceededException 정원 초과 시 예외 발생
+     */
+    private void tryReserveSeatAndEnqueue(Long studentId, Long courseId) {
+        // Redis 키 생성
+        String enrolledKey = "course:" + courseId + ":enrolled";
+        String capacityKey = "course:" + courseId + ":capacity";
+        RAtomicLong enrolled = redisson.getAtomicLong(enrolledKey);
+        RAtomicLong capacity = redisson.getAtomicLong(capacityKey);
+
+        // 중복 enqueue 방지 플래그 키
+        String flagKey = "enroll:queued:" + studentId + ":" + courseId;
+
+        // 1) 자리 확보: 현재 enrolled 값을 1 증가시키고
+        long newCount = enrolled.incrementAndGet();
+        //    증가된 값이 capacity를 넘으면 복구 후 예외
+        if (newCount > capacity.get()) {
+            enrolled.decrementAndGet();                  // 자리 반납
+            redisson.getBucket(flagKey).delete();        // enqueue 플래그 롤백
+            throw new CourseCapacityExceededException(); // 정원 초과 예외
+        }
+
+        try {
+            // 2) Redis 큐에 수강신청 명령 추가
+            enrollQueue.add(new EnrollmentCommand(studentId, courseId));
+        } catch (Exception e) {
+            // 3) enqueue 중 에러 발생 시 복구
+            enrolled.decrementAndGet();                  // 자리 반납
+            redisson.getBucket(flagKey).delete();        // enqueue 플래그 롤백
+            throw e;                                     // 예외 재던짐
+        }
+    }
+
 
     /**
      * 학생이 동일 강좌를 이미 신청하지 않았는지 확인한다.

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/service/async/cancel/EnrollmentCancelCommand.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/service/async/cancel/EnrollmentCancelCommand.java
@@ -1,0 +1,7 @@
+package com.WEB4_5_GPT_BE.unihub.domain.enrollment.service.async.cancel;
+
+public record EnrollmentCancelCommand(
+        Long studentId,
+        Long courseId
+) {
+}

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/service/async/cancel/EnrollmentCancelCommandConsumer.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/service/async/cancel/EnrollmentCancelCommandConsumer.java
@@ -1,0 +1,64 @@
+package com.WEB4_5_GPT_BE.unihub.domain.enrollment.service.async.cancel;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RBlockingQueue;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+
+/**
+ * 수강취소 명령 소비자 컴포넌트
+ * <p>
+ * Redis의 Queue(RBlockingQueue)에서 수강취소 요청(EnrollmentCancelCommand)을 읽어와
+ * 수강취소 명령 처리 핸들러(EnrollmentCancelCommandHandler)를 통해 비동기로 동작합니다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EnrollmentCancelCommandConsumer {
+
+    // 수강취소 처리 로직이 구현된 핸들러
+    private final EnrollmentCancelCommandHandler handler;
+
+    // Redis 기반 큐 (수강취소 명령 대기열)
+    private final RBlockingQueue<EnrollmentCancelCommand> cancelQueue;
+
+    /**
+     * 애플리케이션이 완전히 시작된 후 호출되어
+     * 워커 스레드를 생성·시작합니다.
+     */
+    @EventListener(ApplicationReadyEvent.class)
+    public void start() {
+        Thread worker = new Thread(this::runLoop, "cancel-worker");
+        worker.setDaemon(true);
+        worker.start();
+    }
+
+    /**
+     * 워커 스레드 실행 메서드
+     * <p>
+     * - 큐에 명령이 들어올 때까지 블로킹하여 기다립니다.
+     * - 꺼낸 명령은 handler.process()로 처리합니다.
+     * - 처리 중 문제가 생기면 경고 로그를 남깁니다.
+     * - RBlockingQueue는 Redis 쪽에서 블로킹 호출을 제공하므로,
+     * 메시지가 없을 때는 CPU를 소모하지 않고 메시지 도착 시까지 대기합니다.
+     */
+    private void runLoop() {
+        while (!Thread.currentThread().isInterrupted()) {
+            try {
+                EnrollmentCancelCommand cmd = cancelQueue.take();
+                try {
+                    handler.process(cmd);
+                } catch (Exception ex) {
+                    log.warn("수강취소 처리 중 오류: 학생={} 강의={} 예외={}",
+                            cmd.studentId(), cmd.courseId(), ex.toString());
+                }
+            } catch (InterruptedException ie) {
+                // 인터럽트 발생: 다른 스레드가 이 스레드의 종료를 요청
+                // 스레드의 인터럽트 상태를 다시 설정하고 반복을 종료합니다.
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+}

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/service/async/cancel/EnrollmentCancelCommandHandler.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/service/async/cancel/EnrollmentCancelCommandHandler.java
@@ -1,0 +1,64 @@
+package com.WEB4_5_GPT_BE.unihub.domain.enrollment.service.async.cancel;
+
+import com.WEB4_5_GPT_BE.unihub.domain.course.repository.CourseRepository;
+import com.WEB4_5_GPT_BE.unihub.domain.enrollment.entity.Enrollment;
+import com.WEB4_5_GPT_BE.unihub.domain.enrollment.exception.EnrollmentNotFoundException;
+import com.WEB4_5_GPT_BE.unihub.domain.enrollment.repository.EnrollmentRepository;
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 수강취소 명령 처리 핸들러
+ * ‑ EnrollmentCancelCommand를 받아 DB에서 수강신청 내역을 삭제하고,
+ * Redis에 저장된 강좌별 수강인원 카운터를 동기화합니다.
+ */
+@Service
+@RequiredArgsConstructor
+public class EnrollmentCancelCommandHandler {
+
+    private final EnrollmentRepository enrollmentRepository;
+    private final CourseRepository courseRepository;
+    private final RedissonClient redisson;
+
+    /**
+     * 수강취소 처리 메서드
+     * <p>
+     * - REQUIRES_NEW 트랜잭션으로 독립 커밋/롤백 보장
+     * - 기존 수강신청 엔티티 조회 → 삭제 → 수강가능 인원 카운터 감소
+     * - 처리 중 예외 발생 시 Redis 카운터를 원복하고 예외 처리
+     *
+     * @param cmd 수강취소 명령 (studentId, courseId 포함)
+     * @throws EnrollmentNotFoundException 수강신청 내역이 없는 경우
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void process(EnrollmentCancelCommand cmd) {
+        Long studentId = cmd.studentId();
+        Long courseId = cmd.courseId();
+        String flagKey = "cancel:queued:" + studentId + ":" + courseId;
+
+        try {
+            // 1) 수강신청 내역 조회. 없으면 EnrollmentNotFoundException 발생
+            Enrollment enrollment = enrollmentRepository
+                    .findByCourseIdAndStudentId(courseId, studentId)
+                    .orElseThrow(EnrollmentNotFoundException::new);
+
+            // 2) 조회된 수강신청 삭제
+            enrollmentRepository.delete(enrollment);
+
+            // 3) 강좌 엔티티의 현재 수강인원 감소
+            courseRepository.decrementEnrolled(courseId);
+
+        } catch (Exception e) {
+            // 예외 발생 시 Redis 강좌별 수강인원 카운터 원복 (증가)
+            redisson.getAtomicLong("course:" + courseId + ":enrolled")
+                    .incrementAndGet();
+            throw e;
+        } finally {
+            // 대기열 처리 완료 후 플래그(잠금) 해제
+            redisson.getBucket(flagKey).delete();
+        }
+    }
+}

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/service/async/cancel/EnrollmentCancelDuplicateChecker.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/service/async/cancel/EnrollmentCancelDuplicateChecker.java
@@ -1,0 +1,51 @@
+package com.WEB4_5_GPT_BE.unihub.domain.enrollment.service.async.cancel;
+
+import com.WEB4_5_GPT_BE.unihub.domain.enrollment.exception.RequestAlreadyQueuedException;
+import com.WEB4_5_GPT_BE.unihub.global.concurrent.ConcurrencyGuard;
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RBucket;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+/**
+ * 수강취소 중복 검사 컴포넌트
+ * <p>
+ * 학생(studentId)과 강좌(courseId) 조합에 대해
+ * 이미 취소 큐에 enqueue 되었는지 Redis flag로 검사하고,
+ * 중복 요청 시 예외를 던집니다.
+ *
+ * @ConcurrencyGuard(lockName = "student:cancel") 어노테이션을 통해
+ * 분산 락을 적용하여 동시성 문제를 방지합니다.
+ */
+@Component
+@RequiredArgsConstructor
+public class EnrollmentCancelDuplicateChecker {
+
+    private final RedissonClient redisson;
+
+    /**
+     * 지정된 학생과 강좌 조합에 대해
+     * Redis에 플래그가 없으면 설정하고(1시간 유효),
+     * 이미 존재하면 RequestAlreadyQueuedException을 발생시킵니다.
+     *
+     * @param studentId 학생 ID
+     * @param courseId  강좌 ID
+     * @throws RequestAlreadyQueuedException 이미 대기 중인 경우 발생
+     */
+    @ConcurrencyGuard(lockName = "student:cancel")
+    public void markEnqueuedIfAbsent(Long studentId, Long courseId) {
+        // Redis 키: cancel:queued:{studentId}:{courseId}
+        String key = "cancel:queued:" + studentId + ":" + courseId;
+        RBucket<Boolean> flag = redisson.getBucket(key);
+
+        // 이미 플래그가 설정되어 있으면 중복으로 간주
+        if (flag.isExists()) {
+            throw new RequestAlreadyQueuedException();
+        }
+
+        // 플래그가 없으면 true로 설정하고 1시간 뒤 자동 만료
+        flag.set(true, Duration.ofHours(1));
+    }
+}

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/service/async/enroll/EnrollmentCommand.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/service/async/enroll/EnrollmentCommand.java
@@ -1,0 +1,5 @@
+package com.WEB4_5_GPT_BE.unihub.domain.enrollment.service.async.enroll;
+
+public record EnrollmentCommand(Long studentId, Long courseId) {
+}
+

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/service/async/enroll/EnrollmentCommandConsumer.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/service/async/enroll/EnrollmentCommandConsumer.java
@@ -1,0 +1,66 @@
+package com.WEB4_5_GPT_BE.unihub.domain.enrollment.service.async.enroll;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RBlockingQueue;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+
+
+/**
+ * 수강신청 명령 소비자 컴포넌트
+ * <p>
+ * Redis의 Queue(RBlockingQueue)에서 수강신청 요청(EnrollmentCommand)을 읽어와
+ * 수강신청 명령 처리 핸들러(EnrollmentCommandHandler)를 통해 비동기로 동작합니다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EnrollmentCommandConsumer {
+
+    // 수강신청 처리 로직이 구현된 핸들러
+    private final EnrollmentCommandHandler processor;
+
+    // Redis 기반 큐 (수강신청 명령 대기열)
+    private final RBlockingQueue<EnrollmentCommand> enrollQueue;
+
+    /**
+     * 애플리케이션이 완전히 시작된 후 호출되어
+     * 워커 스레드를 생성·시작합니다.
+     */
+    @EventListener(ApplicationReadyEvent.class)
+    public void start() {
+        Thread worker = new Thread(this::runLoop, "enroll-worker");
+        worker.setDaemon(true);
+        worker.start();
+    }
+
+    /**
+     * 워커 스레드 실행 메서드
+     *
+     * - 큐에 명령이 들어올 때까지 기다립니다.
+     * - 꺼낸 명령은 processor.process()로 처리합니다.
+     * - 처리 중 문제가 생기면 경고 로그를 남깁니다.
+     * - RBlockingQueue의 경우 Redis 쪽에서 블로킹 호출이 됩니다. 즉 큐에 메시지가 없을 때는 CPU 를 소모하지 않고
+     *   메시지가 들어올 때까지 블록 상태로 존재하여 부하가 적습니다.
+     */
+    private void runLoop() {
+        while (!Thread.currentThread().isInterrupted()) {
+            try {
+                EnrollmentCommand cmd = enrollQueue.take();
+                try {
+                    processor.process(cmd);
+                } catch (Exception ex) {
+                    log.warn("수강신청 처리 중 오류: 학생={} 강의={} 예외={}",
+                            cmd.studentId(), cmd.courseId(), ex.toString());
+                }
+            } catch (InterruptedException ie) {
+                // 인터럽트 발생: 다른 스레드가 이 스레드에 종료를 요청
+                // 반복을 멈추고 스레드를 바로 종료합니다.
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+}

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/service/async/enroll/EnrollmentCommandHandler.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/service/async/enroll/EnrollmentCommandHandler.java
@@ -1,0 +1,76 @@
+package com.WEB4_5_GPT_BE.unihub.domain.enrollment.service.async.enroll;
+
+import com.WEB4_5_GPT_BE.unihub.domain.course.exception.CourseNotFoundException;
+import com.WEB4_5_GPT_BE.unihub.domain.course.repository.CourseRepository;
+import com.WEB4_5_GPT_BE.unihub.domain.enrollment.entity.Enrollment;
+import com.WEB4_5_GPT_BE.unihub.domain.enrollment.repository.EnrollmentRepository;
+import com.WEB4_5_GPT_BE.unihub.domain.member.exception.mypage.StudentProfileNotFoundException;
+import com.WEB4_5_GPT_BE.unihub.domain.member.repository.StudentRepository;
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 수강신청 명령 처리 핸들러
+ * ‑ EnrollmentCommand를 받아 실제 DB에 저장하고,
+ * Redis에 저장된 강좌별 수강인원 카운터를 동기화합니다.
+ */
+@Service
+@RequiredArgsConstructor
+public class EnrollmentCommandHandler {
+
+    private final EnrollmentRepository enrollmentRepository;
+    private final CourseRepository courseRepository;
+    private final StudentRepository studentRepository;
+
+    // Redis 연동용 Redisson 클라이언트 (수강인원 카운터 조작)
+    private final RedissonClient redisson;
+
+    /**
+     * 수강신청 처리 메서드
+     *
+     * - REQUIRES_NEW 트랜잭션으로 독립 커밋/롤백 보장
+     * - 학생/강좌 조회 → 수강신청 기록 저장 → 수강인원 카운터 증가
+     * - 처리 중 예외 발생 시 Redis 카운터를 원복하고 예외 던짐
+     *
+     * @param cmd 수강신청 명령 (studentId, courseId 포함)
+     * @throws StudentProfileNotFoundException 학생 정보가 없는 경우
+     * @throws CourseNotFoundException 강좌 정보가 없는 경우
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void process(EnrollmentCommand cmd) {
+        Long studentId = cmd.studentId();
+        Long courseId = cmd.courseId();
+        String flagKey = "enroll:queued:" + studentId + ":" + courseId;
+
+        try {
+            // 1) 학생 조회, 없으면 예외
+            var student = studentRepository.findById(studentId)
+                    .orElseThrow(StudentProfileNotFoundException::new);
+
+            // 2) 강좌 조회, 없으면 예외
+            var course = courseRepository.findById(courseId)
+                    .orElseThrow(CourseNotFoundException::new);
+
+            // 3) 수강신청 엔티티 생성 및 저장
+            Enrollment enrollment = Enrollment.builder()
+                    .student(student)
+                    .course(course)
+                    .build();
+            enrollmentRepository.save(enrollment);
+
+            // 4) DB에 강좌 수강인원 카운터 증가
+            courseRepository.incrementEnrolled(courseId);
+
+        } catch (Exception e) {
+            // 예외 발생 시 Redis 카운터 원복 (감소)
+            redisson.getAtomicLong("course:" + courseId + ":enrolled")
+                    .decrementAndGet();
+            throw e;
+        } finally {
+            redisson.getBucket(flagKey).delete(); // 큐가 처리되고 나면 flag 해제
+        }
+    }
+}

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/service/async/enroll/EnrollmentDuplicateChecker.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/service/async/enroll/EnrollmentDuplicateChecker.java
@@ -1,0 +1,51 @@
+package com.WEB4_5_GPT_BE.unihub.domain.enrollment.service.async.enroll;
+
+import com.WEB4_5_GPT_BE.unihub.domain.enrollment.exception.RequestAlreadyQueuedException;
+import com.WEB4_5_GPT_BE.unihub.global.concurrent.ConcurrencyGuard;
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RBucket;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+/**
+ * 수강신청 중복 검사 컴포넌트
+ *
+ * 학생(studentId)과 강좌(courseId) 조합에 대해
+ * 이미 enqueue 되어있는지 flag를 통해 검사하고,
+ * 중복 등록 시 예외를 던집니다.
+ *
+ * @ConcurrencyGuard(lockName = "student:enroll") 어노테이션을 통해
+ * 분산 락을 적용하여 동시성 문제를 방지합니다.
+ */
+@Component
+@RequiredArgsConstructor
+public class EnrollmentDuplicateChecker {
+
+    private final RedissonClient redisson;
+
+    /**
+     * 지정된 학생과 강좌 조합에 대해
+     * Redis에 플래그가 없으면 설정하고(1시간 유효),
+     * 이미 존재하면 DuplicateEnrollmentException을 발생시킵니다.
+     *
+     * @param studentId 학생 ID
+     * @param courseId  강좌 ID
+     * @throws RequestAlreadyQueuedException 이미 대기 중인 경우 발생
+     */
+    @ConcurrencyGuard(lockName = "student:enroll")
+    public void markEnqueuedIfAbsent(Long studentId, Long courseId) {
+        // Redis 키: enroll:queued:{studentId}:{courseId}
+        String flagKey = "enroll:queued:" + studentId + ":" + courseId;
+        RBucket<Boolean> flag = redisson.getBucket(flagKey);
+
+        // 이미 플래그가 설정되어 있으면 중복으로 간주
+        if (flag.isExists()) {
+            throw new RequestAlreadyQueuedException();
+        }
+
+        // 플래그가 없으면 true로 설정하고 1시간 뒤 자동 만료
+        flag.set(true, Duration.ofHours(1));
+    }
+}

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/concurrent/ConcurrencyGuard.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/concurrent/ConcurrencyGuard.java
@@ -1,0 +1,29 @@
+package com.WEB4_5_GPT_BE.unihub.global.concurrent;
+
+import org.springframework.context.annotation.Profile;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * ConcurrencyGuard 애노테이션은 메서드 실행 전 분산 락을 사용해
+ * 동시 접근을 제어합니다.
+ */
+@Documented
+@Profile("!test")
+@Target(METHOD)            // 해당 애노테이션을 메서드에만 적용할 수 있도록 지정
+@Retention(RUNTIME)        // 런타임 시점까지 애노테이션 정보를 유지하여 AOP 등에서 활용할 수 있게 함
+public @interface ConcurrencyGuard {
+    String lockName(); // 락을 식별할 이름(key)을 지정
+
+    long waitTime() default 5L; // 락 획득을 시도할 최대 대기 시간
+
+    long leaseTime() default 3L; // 락을 획득한 이후 유지할 시간, 해당 시간이 지나면 락이 자동 해제됨
+
+    TimeUnit timeUnit() default TimeUnit.SECONDS; // waitTime과 leaseTime에 사용될 시간 단위
+}

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/concurrent/ConcurrencyGuardAspect.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/concurrent/ConcurrencyGuardAspect.java
@@ -1,0 +1,87 @@
+package com.WEB4_5_GPT_BE.unihub.global.concurrent;
+
+import com.WEB4_5_GPT_BE.unihub.global.concurrent.exception.ConcurrencyLockException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+
+@Slf4j
+@Aspect
+@Component
+@Profile("!test")
+@RequiredArgsConstructor
+public class ConcurrencyGuardAspect {
+
+    private final RedissonClient redissonClient;
+    private final TransactionAspect transactionAspect;
+
+    /**
+     * 분산 락을 걸고, 새로운 트랜잭션에서 비즈니스 로직을 수행한 뒤 락을 해제합니다.
+     */
+    @Around("@annotation(ConcurrencyGuard) && (args(..))")
+    public Object handleConcurrency(ProceedingJoinPoint joinPoint) throws Throwable {
+
+        // 1) 어노테이션 설정 정보 가져오기
+        ConcurrencyGuard annotation = getAnnotation(joinPoint);
+
+        // 2) 메서드 인자를 가져온 뒤 해당 정보(ex: courseId)로 락 이름을 생성
+        Object[] args = joinPoint.getArgs();
+        String lockName = getLockName(args, annotation);
+
+        // 해당 lockName으로 된 Redisson 분산 락 객체 생성
+        RLock lock = redissonClient.getLock(lockName);
+
+        try {
+            // 3) 락 획득 시도 (대기시간 waitTime, 유지시간 leaseTime)
+            boolean available = lock.tryLock(annotation.waitTime(), annotation.leaseTime(), annotation.timeUnit());
+            if (!available) {
+                // 락을 얻지 못하면 예외 발생
+                throw new ConcurrencyLockException();
+            }
+            /*
+             * 락을 획득하게 되면 해당 비즈니스 로직이 새로운 트랜잭션에서 실행될 수 있도록
+             * transactionAspect에 넘겨줌
+             */
+            return transactionAspect.proceed(joinPoint);
+        } finally {
+            // 5) 락 해제
+            try {
+                lock.unlock();
+            } catch (IllegalMonitorStateException e) {
+                log.warn("Redisson 락이 이미 해제되었습니다 lockName: " + lockName); // 이미 해제된 경우 경고 로그
+            }
+        }
+    }
+
+    /**
+     * 실행 되는 메서드에 존재하는 어노테이션 정보를 가져와
+     * ConcurrencyGuard 어노테이션 정보를 추출합니다.
+     */
+    private ConcurrencyGuard getAnnotation(ProceedingJoinPoint joinPoint) {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        return method.getAnnotation(ConcurrencyGuard.class);
+    }
+
+    /**
+     * 락 이름을 "lock:{lockName}:{key}" 형식으로 생성합니다.
+     * args[1]이 Long 타입의 courseId라고 가정하여 활용합니다. -> ex) lock:course:1
+     */
+    private String getLockName(Object[] args, ConcurrencyGuard annotation) {
+        String lockNameFormat = "lock:%s:%s";
+        String lockName = annotation.lockName();
+        String relevantParameter = (args.length > 1 && args[1] != null)
+                ? args[1].toString()
+                : "default";
+        return lockNameFormat.formatted(lockName, relevantParameter);
+    }
+}

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/concurrent/RedisQueueConfig.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/concurrent/RedisQueueConfig.java
@@ -1,0 +1,29 @@
+package com.WEB4_5_GPT_BE.unihub.global.concurrent;
+
+import com.WEB4_5_GPT_BE.unihub.domain.enrollment.service.async.cancel.EnrollmentCancelCommand;
+import com.WEB4_5_GPT_BE.unihub.domain.enrollment.service.async.enroll.EnrollmentCommand;
+import org.redisson.api.RBlockingQueue;
+import org.redisson.api.RedissonClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("!test")
+@Configuration
+public class RedisQueueConfig {
+    /**
+     * 수강신청 요청을 위한 Redis BlockingQueue
+     */
+    @Bean
+    public RBlockingQueue<EnrollmentCommand> enrollQueue(RedissonClient redisson) {
+        return redisson.getBlockingQueue("enrollQueue");
+    }
+
+    /**
+     * 수강취소 요청을 위한 Redis BlockingQueue
+     */
+    @Bean
+    public RBlockingQueue<EnrollmentCancelCommand> cancelQueue(RedissonClient redisson) {
+        return redisson.getBlockingQueue("cancelQueue");
+    }
+}

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/concurrent/TransactionAspect.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/concurrent/TransactionAspect.java
@@ -1,0 +1,33 @@
+package com.WEB4_5_GPT_BE.unihub.global.concurrent;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * [분산 락 적용 시 내 비즈니스 로직을 독립 트랜잭션으로 실행하기 위한 Aspect]
+ * <p>
+ * 분산 락 처리와는 별도로 새로운 트랜잭션을 시작하여 비즈니스 로직을 처리하도록 합니다.
+ * 락 → (새 트랜잭션) → 비즈니스 로직 실행 → (새 트랜잭션 커밋) → 락 해제
+ * 순서를 확실히 분리함으로써 다른 스레드는 커밋이 완료된 데이터만을 사용할 수 있게되며
+ * 이를 통해 데이터 정합성을 보장할 수 있습니다.
+ */
+@Component
+@Profile("!test")
+public class TransactionAspect {
+    /**
+     * [propagation = REQUIRES_NEW]
+     * - 부모 트랜잭션이 존재해도 이를 일시 중단시키고 새로운 트랜잭션을 생성
+     * <p>
+     * [timeout = 2]
+     * - 지정된 시간 내에 커밋되지 않으면 롤백 발생
+     * - 락 해제 시점(leaseTime=3L)보다 트랜잭션 강제종료(timeout=2L) 시점이 짧도록 설정하여
+     * 락이 자동 해제되기 전에 트랜잭션이 끝나도록 설정합니다.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW, timeout = 2)
+    public Object proceed(final ProceedingJoinPoint joinPoint) throws Throwable {
+        return joinPoint.proceed(); // 실제 비즈니스 로직(원본 메서드) 실행
+    }
+}

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/concurrent/exception/ConcurrencyLockException.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/concurrent/exception/ConcurrencyLockException.java
@@ -1,0 +1,9 @@
+package com.WEB4_5_GPT_BE.unihub.global.concurrent.exception;
+
+import com.WEB4_5_GPT_BE.unihub.global.exception.UnihubException;
+
+public class ConcurrencyLockException extends UnihubException {
+    public ConcurrencyLockException() {
+        super("500", "현재 요청을 처리할 수 없습니다. 잠시 후 다시 시도해 주세요.");
+    }
+}

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/config/redisson/RedissonConfig.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/config/redisson/RedissonConfig.java
@@ -1,0 +1,37 @@
+package com.WEB4_5_GPT_BE.unihub.global.config.redisson;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 동시성 제어를 위해 Redisson을 사용하기 위한 설정 클래스입니다.
+ * Redis 서버에 연결하기 위한 RedissonClient를 생성합니다.
+ */
+@Configuration
+public class RedissonConfig {
+    @Value("${spring.data.redis.host}") // Redis 호스트 주소
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}") // Redis 포트 번호
+    private int redisPort;
+
+    @Value("${spring.data.redis.password:}") // Redis 비밀번호 (없을 경우 빈 문자열)
+    private String redisPassword;
+
+    private static final String REDISSON_HOST_PREFIX = "redis://";
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer()
+                // Redis 서버 주소 설정
+                .setAddress(REDISSON_HOST_PREFIX + redisHost + ":" + redisPort)
+                // 비밀번호가 있을 때만 설정 (로컬/배포 환경 모두 대응)
+                .setPassword(redisPassword.isEmpty() ? null : redisPassword);
+        return Redisson.create(config);
+    }
+}

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/init/InitDevData.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/init/InitDevData.java
@@ -117,6 +117,16 @@ public class InitDevData {
                 "thirdstudent@auni.ac.kr", "studentPw3", "정하늘", "20250003",
                 university.getId(), majorSW.getId(), 2, 1
         );
+
+        helper.createEnrollmentPeriod(
+                university,
+                LocalDate.now().getYear(), 4, 1,
+                LocalDate.of(2025, 5, 1),
+                LocalDate.of(2025, 5, 30)
+        );
+
+        // 11) 동시성 테스트용 데이터 생성 (4학년 학생 100명, 교수 1명, 강좌 1개)
+        createTestDataForConcurrency(university, majorSW);
     }
 
     /**
@@ -262,5 +272,29 @@ public class InitDevData {
                 "여름학기 수강신청이 시작됩니다.",
                 summerUrl
         );
+    }
+
+    private void createTestDataForConcurrency(University university, Major majorSW) {
+        for (int i = 1; i <= 100; i++) {
+            helper.createStudent(
+                    "concurrencyStudent" + i + "@auni.ac.kr", "studentPw", "동시성학생" + i, "2504%04d".formatted(i),
+                    university.getId(), majorSW.getId(), 4, 1
+            );
+        }
+
+        Professor professor = (Professor) helper.createProfessor(
+                "concurrencyProfessor@auni.ac.kr", "password", "동시성교수", "EMP250011",
+                university.getId(), majorSW.getId(), ApprovalStatus.APPROVED
+        );
+
+        // 자료구조
+        Course dataStructure = helper.createCourse(
+                "동시성과목", majorSW, "동시관 401호",
+                30, 0, 3,
+                professor,
+                4, 1, "/plans/data-structure.pdf"
+        );
+        helper.createCourseScheduleAndAssociateWithCourse(dataStructure, DayOfWeek.MON, "09:00:00", "10:30:00");
+
     }
 }

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/init/redis/InitDevRedisData.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/init/redis/InitDevRedisData.java
@@ -1,0 +1,56 @@
+package com.WEB4_5_GPT_BE.unihub.global.init.redis;
+
+import com.WEB4_5_GPT_BE.unihub.domain.course.entity.Course;
+import com.WEB4_5_GPT_BE.unihub.domain.course.repository.CourseRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.BatchResult;
+import org.redisson.api.RBatch;
+import org.redisson.api.RedissonClient;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Profile({"dev"})
+@DependsOn("initDevData") // 데이터 초기화 이후 동작하도록 설정
+public class InitDevRedisData {
+
+    private final CourseRepository courseRepository;
+    private final RedissonClient redisson;
+
+    /**
+     * 애플리케이션이 시작될 때 DB에 저장된 모든 강좌를 조회해
+     * Redis의 capacity/enrolled 카운터를 동기화합니다.
+     */
+    @PostConstruct
+    public void initCourseCounters() {
+        List<Course> courses = courseRepository.findAll();
+        log.info("초기화: Redis에 {}개의 강좌 카운터를 동기화합니다.", courses.size());
+
+        // 1) 배치 생성 (파이프라이닝)
+        // 여러 Redis 명령을 “파이프라인”처럼 묶어서 한 번에 전송할 수 있는 RBatch API
+        RBatch batch = redisson.createBatch();
+
+        for (Course course : courses) {
+            String capacityKey = "course:" + course.getId() + ":capacity";
+            String enrolledKey = "course:" + course.getId() + ":enrolled";
+
+            // setAsync() 로 예약만 해 두고, batch.execute()로 한 번에 Redis에 전송합니다.
+            // 네트워크 왕복(RTT) 횟수가 크게 줄어들기 때문에 대량 초기화 시 성능 이점
+            batch.getAtomicLong(capacityKey).setAsync(course.getCapacity());
+            batch.getAtomicLong(enrolledKey).setAsync(course.getEnrolled());
+        }
+
+        // 3) 한 번의 네트워크 왕복으로 실행
+        BatchResult<?> result = batch.execute();
+
+        log.info("초기화 완료: Redis 강좌 카운터 동기화가 끝났습니다. ({} commands)",
+                result.getResponses().size());
+    }
+}

--- a/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/init/redis/InitProdOrStgRedisData.java
+++ b/backend/src/main/java/com/WEB4_5_GPT_BE/unihub/global/init/redis/InitProdOrStgRedisData.java
@@ -1,0 +1,57 @@
+package com.WEB4_5_GPT_BE.unihub.global.init.redis;
+
+import com.WEB4_5_GPT_BE.unihub.domain.course.entity.Course;
+import com.WEB4_5_GPT_BE.unihub.domain.course.repository.CourseRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.BatchResult;
+import org.redisson.api.RBatch;
+import org.redisson.api.RedissonClient;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Profile({"stg", "prod"})
+@DependsOn("initProdOrStgData") // 데이터 초기화 이후 동작하도록 설정
+public class InitProdOrStgRedisData {
+
+    private final CourseRepository courseRepository;
+    private final RedissonClient redisson;
+
+    /**
+     * 애플리케이션이 시작될 때 DB에 저장된 모든 강좌를 조회해
+     * Redis의 capacity/enrolled 카운터를 동기화합니다.
+     */
+    @PostConstruct
+    public void initCourseCounters() {
+        List<Course> courses = courseRepository.findAll();
+        log.info("초기화: Redis에 {}개의 강좌 카운터를 동기화합니다.", courses.size());
+
+        // 1) 배치 생성 (파이프라이닝)
+        // 여러 Redis 명령을 “파이프라인”처럼 묶어서 한 번에 전송할 수 있는 RBatch API
+        RBatch batch = redisson.createBatch();
+
+        for (Course course : courses) {
+            String capacityKey = "course:" + course.getId() + ":capacity";
+            String enrolledKey = "course:" + course.getId() + ":enrolled";
+
+            // setAsync() 로 예약만 해 두고, batch.execute()로 한 번에 Redis에 전송합니다.
+            // 네트워크 왕복(RTT) 횟수가 크게 줄어들기 때문에 대량 초기화 시 성능 이점
+            batch.getAtomicLong(capacityKey).setAsync(course.getCapacity());
+            batch.getAtomicLong(enrolledKey).setAsync(course.getEnrolled());
+        }
+
+        // 3) 한 번의 네트워크 왕복으로 실행
+        BatchResult<?> result = batch.execute();
+
+        log.info("초기화 완료: Redis 강좌 카운터 동기화가 끝났습니다. ({} commands)",
+                result.getResponses().size());
+    }
+}
+

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -12,6 +12,7 @@ spring:
     redis:
       host: localhost # 로컬 Redis 서버 호스트
       port: 6379
+      password:
 
 logging:
   level: # 개발환경에서는 모든 TRACE와 DEBUG 로그를 확인할 수 있도록 설정

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -1,3 +1,6 @@
 spring:
   datasource:
     url: jdbc:h2:mem:unihub_test;MODE=MySQL
+  jpa:
+    hibernate:
+      ddl-auto: create-drop

--- a/backend/src/test/java/com/WEB4_5_GPT_BE/unihub/domain/course/controller/CourseControllerTest.java
+++ b/backend/src/test/java/com/WEB4_5_GPT_BE/unihub/domain/course/controller/CourseControllerTest.java
@@ -156,7 +156,7 @@ class CourseControllerTest {
 //                    .content(objectMapper.writeValueAsString(CourseRequest.from(testCourse))));
 
         // 1) service stub: CourseRequest + no file
-        given(courseService.createCourse(any(CourseWithOutUrlRequest.class), isNull()))
+        given(courseService.createCourse(any(CourseWithOutUrlRequest.class), isNull(), isNull()))
                 .willReturn(CourseWithFullScheduleResponse.from(testCourse));
 
         // 2) JSON part 준비 (@RequestPart("data"))
@@ -184,7 +184,7 @@ class CourseControllerTest {
                 .andExpect(jsonPath("$.data.schedule", hasSize(2)))
                 .andExpect(jsonPath("$.data.schedule[0].day").value(testCourse.getSchedules().getFirst().getDay().toString()));
         then(courseService).should()
-                .createCourse(any(CourseWithOutUrlRequest.class), isNull());
+                .createCourse(any(CourseWithOutUrlRequest.class), isNull(), isNull());
     }
 
     @Test
@@ -208,7 +208,7 @@ class CourseControllerTest {
         courseWithAttachment.getSchedules().addAll(testCourse.getSchedules());
 
         // — 2) 서비스 스텁: 2-arg 버전에 스텁을 걸어줌
-        given(courseService.createCourse(any(CourseWithOutUrlRequest.class), any(MultipartFile.class)))
+        given(courseService.createCourse(any(CourseWithOutUrlRequest.class), any(MultipartFile.class), isNull()))
                 .willReturn(CourseWithFullScheduleResponse.from(courseWithAttachment));
 
         // — 3) JSON data 파트
@@ -249,6 +249,7 @@ class CourseControllerTest {
         given(courseService.updateCourse(
                 eq(courseId),
                 any(CourseWithOutUrlRequest.class),
+                isNull(),
                 isNull()
         )).willReturn(CourseWithFullScheduleResponse.from(testCourse));
 
@@ -281,6 +282,7 @@ class CourseControllerTest {
         verify(courseService).updateCourse(
                 idCaptor.capture(),
                 reqCaptor.capture(),
+                isNull(),
                 isNull()
         );
         assertThat(idCaptor.getValue()).isEqualTo(courseId);
@@ -312,7 +314,8 @@ class CourseControllerTest {
         given(courseService.updateCourse(
                 eq(courseId),
                 any(CourseWithOutUrlRequest.class),
-                any(MultipartFile.class))
+                any(MultipartFile.class),
+                isNull())
         ).willReturn(CourseWithFullScheduleResponse.from(courseWithNewAttachment));
 
         // 3) JSON part
@@ -338,7 +341,7 @@ class CourseControllerTest {
                 .andExpect(jsonPath("$.data.coursePlanAttachment").value(newUrl));
 
         then(courseService).should()
-                .updateCourse(eq(courseId), any(CourseWithOutUrlRequest.class), any(MultipartFile.class));
+                .updateCourse(eq(courseId), any(CourseWithOutUrlRequest.class), any(MultipartFile.class), isNull());
     }
 
     @Test

--- a/backend/src/test/java/com/WEB4_5_GPT_BE/unihub/domain/course/service/CourseServiceTest.java
+++ b/backend/src/test/java/com/WEB4_5_GPT_BE/unihub/domain/course/service/CourseServiceTest.java
@@ -48,6 +48,7 @@ import static org.assertj.core.api.BDDAssertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.doNothing;
 
 @DisplayName("강의 도메인 서비스 레이어 테스트")
 @ExtendWith(MockitoExtension.class)
@@ -73,6 +74,9 @@ class CourseServiceTest {
 
     @Mock
     private EnrollmentRepository enrollmentRepository;
+
+    @Mock
+    private CourseRedisCounterService courseRedisCounterService;
 
     @InjectMocks
     private CourseService courseService;
@@ -165,6 +169,9 @@ class CourseServiceTest {
     @Test
     @DisplayName("스케줄이 없는 강의를 생성할때 정상 생성된다.")
     void givenCourseWithoutSchedule_whenCreatingCourse_thenSaveCourse() {
+
+        doNothing().when(courseRedisCounterService).syncCourseCounters(any(Course.class));
+
         CourseRequest testCourseRequest = new CourseRequest("testCourseRequest3", testMajor2.getName(), testUniversity1.getName(),
                 "nonexistentLocation", 40, 3, testProfessorProfile1.getEmployeeId(), 4, 2, null, List.of());
         given(universityRepository.findByName(testUniversity1.getName())).willReturn(Optional.of(testUniversity1));
@@ -186,6 +193,9 @@ class CourseServiceTest {
     @Test
     @DisplayName("스케줄이 중복되지 않는 강의를 생성할때 정상 생성된다.")
     void givenCourseWithNonconflictingSchedule_whenCreatingCourse_thenSaveCourse() {
+
+        doNothing().when(courseRedisCounterService).syncCourseCounters(any(Course.class));
+
         given(universityRepository.findByName(testUniversity1.getName())).willReturn(Optional.of(testUniversity1));
         given(majorRepository.findByUniversityIdAndName(testUniversity1.getId(), testCourseRequest3.major()))
                 .willReturn(Optional.of(testCourse2.getMajor()));
@@ -481,6 +491,8 @@ class CourseServiceTest {
         given(courseRepository.findById(courseId)).willReturn(Optional.of(course));
         // ↳ 수강신청이 하나도 없다고 강제
         given(enrollmentRepository.existsByCourseId(courseId)).willReturn(false);
+
+        doNothing().when(courseRedisCounterService).deleteCourseCounters(any(Course.class));
 
         // when
         courseService.deleteCourse(courseId);

--- a/backend/src/test/java/com/WEB4_5_GPT_BE/unihub/domain/course/service/CourseServiceTest.java
+++ b/backend/src/test/java/com/WEB4_5_GPT_BE/unihub/domain/course/service/CourseServiceTest.java
@@ -138,6 +138,7 @@ class CourseServiceTest {
         testCourseRequest3 = new CourseRequest("testCourseRequest3", testMajor2.getName(), testUniversity1.getName(),
                 "nonexistentLocation", 40, 3, testProfessorProfile1.getEmployeeId(), 4, 2, null,
                 List.of(new CourseScheduleDto(DayOfWeek.TUE, "13:00", "14:00")));
+        testAuthUser1 = new SecurityUser(testProfessorProfile1, List.of(new SimpleGrantedAuthority("ROLE_PROFESSOR")));
     }
 
     @Test

--- a/backend/src/test/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/service/EnrollmentQueueServiceTest.java
+++ b/backend/src/test/java/com/WEB4_5_GPT_BE/unihub/domain/enrollment/service/EnrollmentQueueServiceTest.java
@@ -50,20 +50,22 @@ public class EnrollmentQueueServiceTest {
     @DisplayName("사용자가 즉시 접속이 허용되는 경우 테스트")
     public void testAddToQueueWithImmediateAccess() {
         // Given
-        when(valueOperations.increment(ACTIVE_USERS_KEY, 0)).thenReturn(2L); // 활성 사용자가 한계보다 적음
+        // Mock getActiveUserCount to return a low number of active users
+        EnrollmentQueueService spyService = spy(enrollmentQueueService);
+        doReturn(2L).when(spyService).getActiveUserCount();
+
         when(redisTemplate.hasKey(SESSION_PREFIX + TEST_MEMBER_ID)).thenReturn(false);
         when(listOperations.range(WAITING_QUEUE_KEY, 0, -1)).thenReturn(Collections.emptyList());
 
         // When
-        QueueStatusDto result = enrollmentQueueService.addToQueue(TEST_MEMBER_ID);
+        QueueStatusDto result = spyService.addToQueue(TEST_MEMBER_ID);
 
         // Then
         assertTrue(result.isAllowed());
         assertEquals(0, result.getPosition());
         assertEquals(0, result.getEstimatedWaitTime());
 
-        // 세션 설정과 카운터 증가 확인
-        verify(valueOperations).increment(ACTIVE_USERS_KEY);
+        // 세션 설정 확인
         verify(valueOperations).set(eq(SESSION_PREFIX + TEST_MEMBER_ID), eq("active"), any(Duration.class));
         verify(sseEmitterService).sendQueueStatus(eq(TEST_MEMBER_ID), any(QueueStatusDto.class));
     }
@@ -72,16 +74,19 @@ public class EnrollmentQueueServiceTest {
     @DisplayName("사용자가 대기열에 추가되는 경우 테스트")
     public void testAddToQueueWithWaiting() {
         // Given
-        when(valueOperations.increment(ACTIVE_USERS_KEY, 0)).thenReturn(1000L); // 활성 사용자가 한계에 도달
+        // Mock getActiveUserCount to return a high number of active users (max reached)
+        EnrollmentQueueService spyService = spy(enrollmentQueueService);
+        doReturn(1000L).when(spyService).getActiveUserCount();
+
         when(redisTemplate.hasKey(SESSION_PREFIX + TEST_MEMBER_ID)).thenReturn(false);
         when(listOperations.range(WAITING_QUEUE_KEY, 0, -1)).thenReturn(Collections.emptyList());
 
         // When
-        QueueStatusDto result = enrollmentQueueService.addToQueue(TEST_MEMBER_ID);
+        QueueStatusDto result = spyService.addToQueue(TEST_MEMBER_ID);
 
         // Then
         assertFalse(result.isAllowed());
-        assertEquals(0, result.getPosition()); // 첫 번째 대기자 (0 기반)
+        assertEquals(0, result.getPosition()); // 첨 번째 대기자 (0 기반)
         assertEquals(0, result.getEstimatedWaitTime()); // 실제 구현에서는 0부터 시작
 
         // 대기열에 추가 확인
@@ -93,7 +98,7 @@ public class EnrollmentQueueServiceTest {
     @DisplayName("최대 접속자 3명 제한 도달 시 새 사용자가 대기열로 이동하는 테스트")
     public void testMaxConcurrentUsers() {
         // 테스트용 객체 생성
-        EnrollmentQueueService testService = new EnrollmentQueueService(redisTemplate, sseEmitterService) {
+        EnrollmentQueueService testService = spy(new EnrollmentQueueService(redisTemplate, sseEmitterService) {
             @Override
             public int getPositionInQueue(String memberId) {
                 // 여기서는 직접 3번째 위치에 있다고 가정
@@ -105,12 +110,12 @@ public class EnrollmentQueueServiceTest {
                 // 처음에는 대기열에 없다고 가정
                 return false;
             }
-        };
+        });
 
         // Given
         String newUserId = "999";
         // 활성 사용자가 3명으로 제한에 도달
-        when(valueOperations.increment(ACTIVE_USERS_KEY, 0)).thenReturn(3L);
+        doReturn(3L).when(testService).getActiveUserCount();
         when(redisTemplate.hasKey(SESSION_PREFIX + newUserId)).thenReturn(false);
 
         // When
@@ -170,19 +175,19 @@ public class EnrollmentQueueServiceTest {
     public void testReleaseSession() {
         // Given
         when(redisTemplate.hasKey(SESSION_PREFIX + TEST_MEMBER_ID)).thenReturn(true);
-        when(valueOperations.increment(ACTIVE_USERS_KEY, 0)).thenReturn(2L); // 여유 공간 있음
+        // Mock getActiveUserCount to return a number below max concurrent users
+        EnrollmentQueueService spyService = spy(enrollmentQueueService);
+        doReturn(2L).when(spyService).getActiveUserCount();
         when(listOperations.leftPop(WAITING_QUEUE_KEY)).thenReturn("2"); // 다음 대기자
 
         // When
-        enrollmentQueueService.releaseSession(TEST_MEMBER_ID);
+        spyService.releaseSession(TEST_MEMBER_ID);
 
         // Then
         // 세션 삭제 확인
         verify(redisTemplate).delete(SESSION_PREFIX + TEST_MEMBER_ID);
-        verify(valueOperations).decrement(ACTIVE_USERS_KEY);
 
         // 다음 사용자 처리 확인
-        verify(valueOperations).increment(ACTIVE_USERS_KEY);
         verify(valueOperations).set(eq(SESSION_PREFIX + "2"), eq("active"), any(Duration.class));
         verify(sseEmitterService).sendQueueStatus(eq("2"), argThat(QueueStatusDto::isAllowed));
     }
@@ -195,11 +200,13 @@ public class EnrollmentQueueServiceTest {
                 .thenReturn(Arrays.asList("2", "3", "4"));
 
         // processNextInQueue를 통해 sendQueueStatusMessages 호출 트리거
-        when(valueOperations.increment(ACTIVE_USERS_KEY, 0)).thenReturn(2L);
+        // Mock getActiveUserCount to return a number below max concurrent users
+        EnrollmentQueueService spyService = spy(enrollmentQueueService);
+        doReturn(2L).when(spyService).getActiveUserCount();
         when(listOperations.leftPop(WAITING_QUEUE_KEY)).thenReturn("5");
 
         // When
-        enrollmentQueueService.processNextInQueue();
+        spyService.processNextInQueue();
 
         // Then
         // 메시지 전송 확인 (배치 처리 로직에 따라 다를 수 있음)

--- a/backend/src/test/java/com/WEB4_5_GPT_BE/unihub/domain/member/controller/TokenAuthIntegrationTest.java
+++ b/backend/src/test/java/com/WEB4_5_GPT_BE/unihub/domain/member/controller/TokenAuthIntegrationTest.java
@@ -1,12 +1,13 @@
 package com.WEB4_5_GPT_BE.unihub.domain.member.controller;
 
+import com.WEB4_5_GPT_BE.unihub.global.config.RedisTestContainerConfig;
 import com.WEB4_5_GPT_BE.unihub.global.util.Ut;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
@@ -20,6 +21,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ActiveProfiles("test")
 @SpringBootTest
 @AutoConfigureMockMvc
+@RedisTestContainerConfig
 public class TokenAuthIntegrationTest {
 
     @Autowired private MockMvc mockMvc;


### PR DESCRIPTION
## ✨ 변경 사항 설명
`CourseController`의 `createCourse` 및 `updateCourse`에서 `@AuthenticationPrincipal`로 인증 유저 정보를 받아오도록 변경.
`CourseService`의 `createCourse` 및 `updateCourse`에서 요청 본문 (`CourseRequest`) 대신 인증 유저로부터 대학 정보를 받아오도록 변경.
`CourseRequest` DTO 클래스의 `university` 필드(대학 이름)에서 `@NotEmpty` 제거.
변경 사항 테스트에 반영.

## ✅ 체크리스트

<!-- 📝 완료된 항목은 [x]로 표시해주세요. -->

- [x] 🏗️ 코드가 **코딩 스타일 가이드**를 준수합니다.
- [x] 🧪 변경 사항에 대한 **테스트가 추가**되었습니다.
- [x] ✅ 모든 **테스트가 정상적으로 통과**합니다.
- [x] 📚 필요한 **문서가 업데이트**되었습니다.

Closes #177.